### PR TITLE
add <cinttypes> to cr_signal.cc

### DIFF
--- a/src/cr_signal.cc
+++ b/src/cr_signal.cc
@@ -9,6 +9,7 @@ extern "C" {
 #include <signal.h>
 
 #include <atomic>
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <string>


### PR DESCRIPTION
missing `<cinttypes>` header cause to compile error when execute `build_all.sh`:

```
Use --sandbox_debug to see verbose messages from the sandbox
external/criscore/src/cr_signal.cc:51:51: error: expected ')'
             "**** Signal %d (%s) received (@0x%" PRIxPTR ") ****",
                                                  ^
external/criscore/src/cr_signal.cc:49:13: note: to match this '('
    snprintf(buffer,
            ^
external/criscore/src/cr_signal.cc:60:32: error: expected ')'
             "PID %d, TID 0x%" PRIxPTR ", from PID %d",
                               ^
external/criscore/src/cr_signal.cc:58:13: note: to match this '('
    snprintf(buffer,
            ^
2 errors generated.
```

fix it by add `<cinttypes>` into `cr_signal.cc`.