### PR TITLE
Support subid for message subscription

### DIFF
--- a/includes/message/base.h
+++ b/includes/message/base.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <typeindex>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
 namespace cris::core {
@@ -25,7 +26,8 @@ concept CRMessageCallbackType = std::is_base_of_v<CRMessageBase, message_t> &&
 
 class CRMessageBase {
    public:
-    using channel_id_t = std::uint64_t;
+    using channel_subid_t = std::uint64_t;
+    using channel_id_t    = std::pair<std::type_index, channel_subid_t>;
 
     CRMessageBase() = default;
 
@@ -37,27 +39,37 @@ class CRMessageBase {
 
     virtual ~CRMessageBase() = default;
 
-    virtual const std::string GetMessageTypeName() const = 0;
+    virtual std::string GetMessageTypeName() const = 0;
 
-    virtual const std::type_index GetMessageTypeIndex() const = 0;
+    virtual std::type_index GetMessageTypeIndex() const = 0;
+
+    channel_subid_t GetChannelSubId() const { return sub_id_; }
+
+    void SetChannelSubId(const channel_subid_t sub_id) { sub_id_ = sub_id; }
+
+    channel_id_t GetChannelId() const;
 
     template<CRMessageType message_t>
-    static cr_timestamp_nsec_t GetLatestDeliveredTime();
+    static cr_timestamp_nsec_t GetLatestDeliveredTime(const channel_subid_t channel_subid);
 
-    static cr_timestamp_nsec_t GetLatestDeliveredTime(const std::type_index message_type);
+    static cr_timestamp_nsec_t GetLatestDeliveredTime(const channel_id_t channel);
 
     static void Dispatch(const std::shared_ptr<CRMessageBase>& message);
+
+    constexpr static channel_subid_t kDefaultChannelSubID = 0;
 
    private:
     // Not thread-safe, do not call concurrently nor call it
     // when messages are coming
-    static bool Subscribe(const std::type_index message_type, CRNodeBase* node);
+    static bool Subscribe(const channel_id_t channel, CRNodeBase* node);
 
     // Not thread-safe, do not call concurrently nor call it
     // when messages are coming
-    static void Unsubscribe(const std::type_index message_type, CRNodeBase* node);
+    static void Unsubscribe(const channel_id_t channel, CRNodeBase* node);
 
     friend class CRNode;
+
+    channel_subid_t sub_id_{kDefaultChannelSubID};
 };
 
 using CRMessageBasePtr = std::shared_ptr<CRMessageBase>;
@@ -65,14 +77,14 @@ using CRMessageBasePtr = std::shared_ptr<CRMessageBase>;
 template<class message_t>
 class CRMessage : public CRMessageBase {
    public:
-    const std::type_index GetMessageTypeIndex() const override { return std::type_index(typeid(message_t)); }
+    std::type_index GetMessageTypeIndex() const override { return std::type_index(typeid(message_t)); }
 
-    const std::string GetMessageTypeName() const override { return GetTypeName<message_t>(); }
+    std::string GetMessageTypeName() const override { return GetTypeName<message_t>(); }
 };
 
 template<CRMessageType message_t>
-cr_timestamp_nsec_t CRMessageBase::GetLatestDeliveredTime() {
-    return GetLatestDeliveredTime(std::type_index(typeid(message_t)));
+cr_timestamp_nsec_t CRMessageBase::GetLatestDeliveredTime(const CRMessageBase::channel_subid_t channel_subid) {
+    return GetLatestDeliveredTime(std::make_pair(std::type_index(typeid(message_t)), channel_subid));
 }
 
 }  // namespace cris::core

--- a/includes/node/base.h
+++ b/includes/node/base.h
@@ -45,6 +45,17 @@ class CRNodeBase {
 
     void Publish(const channel_subid_t channel_subid, CRMessageBasePtr&& message);
 
+    /* to be deprecated */
+    template<CRMessageType message_t, CRMessageCallbackType<message_t> callback_t>
+    void Subscribe(callback_t&& callback) {
+        return Subscribe<message_t>(CRMessageBase::kDefaultChannelSubID, std::forward<callback_t>(callback));
+    }
+
+    /* to be deprecated */
+    void Publish(CRMessageBasePtr&& message) {
+        return Publish(CRMessageBase::kDefaultChannelSubID, std::move(message));
+    }
+
     virtual CRMessageQueue* MessageQueueMapper(const channel_id_t channel) = 0;
 
     CRMessageQueue* MessageQueueMapper(const CRMessageBasePtr& message);

--- a/includes/node/base.h
+++ b/includes/node/base.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cris/core/message/base.h"
 #include "cris/core/message/queue.h"
 
 #include <chrono>
@@ -12,6 +13,9 @@ namespace cris::core {
 // messages are coming
 class CRNodeBase {
    public:
+    using channel_subid_t = CRMessageBase::channel_subid_t;
+    using channel_id_t    = CRMessageBase::channel_id_t;
+
     CRNodeBase() = default;
 
     CRNodeBase(const CRNodeBase&) = delete;
@@ -37,23 +41,23 @@ class CRNodeBase {
     // when messages are coming, nor call it after Node Runner
     // is Running
     template<CRMessageType message_t, CRMessageCallbackType<message_t> callback_t>
-    void Subscribe(callback_t&& callback);
+    void Subscribe(const channel_subid_t channel_subid, callback_t&& callback);
 
-    void Publish(CRMessageBasePtr&& message);
+    void Publish(const channel_subid_t channel_subid, CRMessageBasePtr&& message);
 
-    virtual CRMessageQueue* MessageQueueMapper(const CRMessageBasePtr& message) = 0;
+    virtual CRMessageQueue* MessageQueueMapper(const channel_id_t channel) = 0;
+
+    CRMessageQueue* MessageQueueMapper(const CRMessageBasePtr& message);
 
     static CRNodeBase* GetMessageManager();
 
    protected:
     virtual void WaitForMessageImpl(std::chrono::nanoseconds timeout) = 0;
 
-    virtual void SubscribeImpl(
-        const std::type_index                          message_type,
-        std::function<void(const CRMessageBasePtr&)>&& callback) = 0;
+    virtual void SubscribeImpl(const channel_id_t channel, std::function<void(const CRMessageBasePtr&)>&& callback) = 0;
 
     virtual void SubscribeHandler(
-        const std::type_index                          message_type,
+        const channel_id_t                             channel,
         std::function<void(const CRMessageBasePtr&)>&& callback) = 0;
 
     virtual std::vector<CRMessageQueue*> GetNodeQueues() = 0;
@@ -70,10 +74,12 @@ void CRNodeBase::WaitForMessage(duration_t&& timeout) {
 }
 
 template<CRMessageType message_t, CRMessageCallbackType<message_t> callback_t>
-void CRNodeBase::Subscribe(callback_t&& callback) {
-    return SubscribeImpl(typeid(message_t), [callback = std::move(callback)](const CRMessageBasePtr& message) {
-        return callback(reinterpret_cast<const std::shared_ptr<message_t>&>(message));
-    });
+void CRNodeBase::Subscribe(const channel_subid_t channel_subid, callback_t&& callback) {
+    return SubscribeImpl(
+        std::make_pair(std::type_index(typeid(message_t)), channel_subid),
+        [callback = std::move(callback)](const CRMessageBasePtr& message) {
+            return callback(reinterpret_cast<const std::shared_ptr<message_t>&>(message));
+        });
 }
 
 }  // namespace cris::core

--- a/includes/node/multi_queue_node.h
+++ b/includes/node/multi_queue_node.h
@@ -5,6 +5,7 @@
 
 #include <boost/functional/hash.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <typeindex>
 #include <unordered_map>
@@ -27,8 +28,8 @@ class CRMultiQueueNodeBase : public CRNode {
 
     std::vector<CRMessageQueue*> GetNodeQueues() override;
 
-    size_t      queue_capacity_;
-    queue_map_t queues_{};
+    std::size_t queue_capacity_;
+    queue_map_t queues_;
 };
 
 template<CRMessageQueueType queue_t = CRMessageLockQueue>

--- a/includes/node/multi_queue_node.h
+++ b/includes/node/multi_queue_node.h
@@ -3,6 +3,8 @@
 #include "cris/core/message/lock_queue.h"
 #include "cris/core/node/node.h"
 
+#include <boost/functional/hash.hpp>
+
 #include <memory>
 #include <typeindex>
 #include <unordered_map>
@@ -13,20 +15,20 @@ class CRMultiQueueNodeBase : public CRNode {
    public:
     explicit CRMultiQueueNodeBase(size_t queue_capacity) : queue_capacity_(queue_capacity) {}
 
-    CRMessageQueue* MessageQueueMapper(const CRMessageBasePtr& message) override;
+    CRMessageQueue* MessageQueueMapper(const channel_id_t channel) override;
 
    protected:
     using queue_callback_t = std::function<void(const CRMessageBasePtr&)>;
+    using queue_map_t = std::unordered_map<channel_id_t, std::unique_ptr<CRMessageQueue>, boost::hash<channel_id_t>>;
 
     virtual std::unique_ptr<CRMessageQueue> MakeMessageQueue(queue_callback_t&& callback) = 0;
 
-    void SubscribeHandler(const std::type_index message_type, std::function<void(const CRMessageBasePtr&)>&& callback)
-        override;
+    void SubscribeHandler(const channel_id_t channel, std::function<void(const CRMessageBasePtr&)>&& callback) override;
 
     std::vector<CRMessageQueue*> GetNodeQueues() override;
 
-    size_t                                                               queue_capacity_;
-    std::unordered_map<std::type_index, std::unique_ptr<CRMessageQueue>> queues_{};
+    size_t      queue_capacity_;
+    queue_map_t queues_{};
 };
 
 template<CRMessageQueueType queue_t = CRMessageLockQueue>

--- a/includes/node/node.h
+++ b/includes/node/node.h
@@ -18,12 +18,11 @@ class CRNode : public CRNodeBase {
    private:
     void WaitForMessageImpl(std::chrono::nanoseconds timeout) override;
 
-    void SubscribeImpl(const std::type_index message_type, std::function<void(const CRMessageBasePtr&)>&& callback)
-        override;
+    void SubscribeImpl(const channel_id_t channel, std::function<void(const CRMessageBasePtr&)>&& callback) override;
 
-    std::vector<std::type_index> subscribed_{};
-    std::mutex                   wait_message_mutex_{};
-    std::condition_variable      wait_message_cv_{};
+    std::vector<channel_id_t> subscribed_{};
+    std::mutex                wait_message_mutex_{};
+    std::condition_variable   wait_message_cv_{};
 };
 
 }  // namespace cris::core

--- a/includes/node/node.h
+++ b/includes/node/node.h
@@ -20,9 +20,9 @@ class CRNode : public CRNodeBase {
 
     void SubscribeImpl(const channel_id_t channel, std::function<void(const CRMessageBasePtr&)>&& callback) override;
 
-    std::vector<channel_id_t> subscribed_{};
-    std::mutex                wait_message_mutex_{};
-    std::condition_variable   wait_message_cv_{};
+    std::vector<channel_id_t> subscribed_;
+    std::mutex                wait_message_mutex_;
+    std::condition_variable   wait_message_cv_;
 };
 
 }  // namespace cris::core

--- a/includes/node/single_queue_node.h
+++ b/includes/node/single_queue_node.h
@@ -14,7 +14,7 @@ class CRSingleQueueNode : public CRNode {
         : queue_capacity_(queue_capacity)
         , queue_(queue_capacity_, this, std::move(callback)) {}
 
-    CRMessageQueue* MessageQueueMapper(const CRMessageBasePtr& message) override { return &queue_; }
+    CRMessageQueue* MessageQueueMapper(const channel_id_t /* channel */) override { return &queue_; }
 
    protected:
     std::vector<CRMessageQueue*> GetNodeQueues() override {

--- a/src/node/base.cc
+++ b/src/node/base.cc
@@ -4,8 +4,15 @@
 
 namespace cris::core {
 
-void CRNodeBase::Publish(CRMessageBasePtr&& message) {
+CRMessageQueue* CRNodeBase::MessageQueueMapper(const CRMessageBasePtr& message) {
+    return MessageQueueMapper(message->GetChannelId());
+}
+
+void CRNodeBase::Publish(const CRNodeBase::channel_subid_t channel_subid, CRMessageBasePtr&& message) {
     auto* message_manager = GetMessageManager();
+
+    message->SetChannelSubId(channel_subid);
+
     message_manager->MessageQueueMapper(message)->AddMessage(std::move(message));
     message_manager->Kick();
 }

--- a/src/node/message_manager.cc
+++ b/src/node/message_manager.cc
@@ -11,8 +11,7 @@ class CRMessageManager : public CRNamedNode<CRMessageManager, CRSingleQueueNode<
         : CRNamedNode<CRMessageManager, CRSingleQueueNode<>>(queue_capacity, &CRMessageBase::Dispatch) {}
 
    private:
-    void SubscribeHandler(const std::type_index message_type, std::function<void(const CRMessageBasePtr&)>&& callback)
-        override;
+    void SubscribeHandler(const channel_id_t channel, std::function<void(const CRMessageBasePtr&)>&& callback) override;
 };
 
 CRNodeBase* CRNodeBase::GetMessageManager() {
@@ -24,8 +23,8 @@ CRNodeBase* CRNodeBase::GetMessageManager() {
 }
 
 void CRMessageManager::SubscribeHandler(
-    const std::type_index                          message_type,
-    std::function<void(const CRMessageBasePtr&)>&& callback) {
+    const channel_id_t /* channel */,
+    std::function<void(const CRMessageBasePtr&)>&& /* callback */) {
     // Message Manager never subscribe to any message
 }
 

--- a/src/node/multi_queue_node.cc
+++ b/src/node/multi_queue_node.cc
@@ -4,8 +4,8 @@
 
 namespace cris::core {
 
-CRMessageQueue* CRMultiQueueNodeBase::MessageQueueMapper(const CRMessageBasePtr& message) {
-    auto queue_search = queues_.find(message->GetMessageTypeIndex());
+CRMessageQueue* CRMultiQueueNodeBase::MessageQueueMapper(const channel_id_t channel) {
+    auto queue_search = queues_.find(channel);
     if (queue_search == queues_.end()) [[unlikely]] {
         return nullptr;
     }
@@ -13,12 +13,12 @@ CRMessageQueue* CRMultiQueueNodeBase::MessageQueueMapper(const CRMessageBasePtr&
 }
 
 void CRMultiQueueNodeBase::SubscribeHandler(
-    const std::type_index                          message_type,
+    const channel_id_t                             channel,
     std::function<void(const CRMessageBasePtr&)>&& callback) {
-    auto insert = queues_.emplace(message_type, MakeMessageQueue(std::move(callback)));
+    auto insert = queues_.emplace(channel, MakeMessageQueue(std::move(callback)));
     if (!insert.second) {
-        LOG(ERROR) << __func__ << ": message '" << message_type.name()
-                   << "' is subscribed. The new callback is ignored. Node: " << this;
+        LOG(ERROR) << __func__ << ": channel (" << channel.first.name() << ", " << channel.second << ") "
+                   << "is subscribed. The new callback is ignored. Node: " << this;
     }
 }
 

--- a/src/node/node.cc
+++ b/src/node/node.cc
@@ -19,14 +19,12 @@ void CRNode::WaitForMessageImpl(std::chrono::nanoseconds timeout) {
     wait_message_cv_.wait_for(lock, timeout);
 }
 
-void CRNode::SubscribeImpl(
-    const std::type_index                          message_type,
-    std::function<void(const CRMessageBasePtr&)>&& callback) {
-    if (!CRMessageBase::Subscribe(message_type, this)) {
+void CRNode::SubscribeImpl(const channel_id_t channel, std::function<void(const CRMessageBasePtr&)>&& callback) {
+    if (!CRMessageBase::Subscribe(channel, this)) {
         return;
     }
-    subscribed_.push_back(message_type);
-    return SubscribeHandler(message_type, std::move(callback));
+    subscribed_.push_back(channel);
+    return SubscribeHandler(channel, std::move(callback));
 }
 
 }  // namespace cris::core

--- a/tests/message_test.cc
+++ b/tests/message_test.cc
@@ -6,10 +6,14 @@
 #include <boost/functional/hash.hpp>
 
 #include <cstdlib>
+#include <functional>
 #include <memory>
 #include <unordered_map>
+#include <utility>
 
 namespace cris::core {
+
+using channel_subid_t = CRMessageBase::channel_subid_t;
 
 template<int idx>
 struct TestMessage : public CRMessage<TestMessage<idx>> {
@@ -54,7 +58,9 @@ TEST(MessageTest, Basics) {
 }
 
 TEST(MessageTest, Subscribe) {
-    CRMessageBasePtr message = std::make_shared<TestMessage<1>>(1);
+    channel_subid_t  channel_subid = 1;
+    CRMessageBasePtr message       = std::make_shared<TestMessage<1>>(1);
+    message->SetChannelSubId(channel_subid);
 
     // Dispatch message
     {
@@ -62,13 +68,19 @@ TEST(MessageTest, Subscribe) {
         int            value = 0;
         SimpleTestNode node(1);
 
-        node.Subscribe<TestMessage<1>>(/*channel_subid = */ 0, [&](const CRMessageBasePtr& message) {
+        // Different subid, never called
+        node.Subscribe<TestMessage<1>>(999, [&](const CRMessageBasePtr&) {
+            // never enters
+            std::abort();
+        });
+
+        node.Subscribe<TestMessage<1>>(channel_subid, [&](const CRMessageBasePtr& message) {
             ++count;
             value = static_pointer_cast<TestMessage<1>>(message)->value_;
         });
 
         // duplicate subscription, first one wins
-        node.Subscribe<TestMessage<1>>(/*channel_subid = */ 0, [&](const CRMessageBasePtr&) {
+        node.Subscribe<TestMessage<1>>(channel_subid, [&](const CRMessageBasePtr&) {
             // never enters
             std::abort();
         });
@@ -87,7 +99,7 @@ TEST(MessageTest, Subscribe) {
         int            count1 = 0;
         int            value1 = 0;
         SimpleTestNode node1(1);
-        node1.Subscribe<TestMessage<1>>(/*channel_subid = */ 0, [&](const CRMessageBasePtr& message) {
+        node1.Subscribe<TestMessage<1>>(channel_subid, [&](const CRMessageBasePtr& message) {
             ++count1;
             value1 = static_pointer_cast<TestMessage<1>>(message)->value_;
         });
@@ -95,7 +107,7 @@ TEST(MessageTest, Subscribe) {
         int            count2 = 0;
         int            value2 = 0;
         SimpleTestNode node2(1);
-        node2.Subscribe<TestMessage<1>>(/*channel_subid = */ 0, [&](const CRMessageBasePtr& message) {
+        node2.Subscribe<TestMessage<1>>(channel_subid, [&](const CRMessageBasePtr& message) {
             ++count2;
             value2 = static_pointer_cast<TestMessage<1>>(message)->value_;
         });
@@ -103,12 +115,13 @@ TEST(MessageTest, Subscribe) {
         int            count3 = 0;
         int            value3 = 0;
         SimpleTestNode node3(1);
-        node3.Subscribe<TestMessage<1>>(/*channel_subid = */ 0, [&](const CRMessageBasePtr& message) {
+        node3.Subscribe<TestMessage<1>>(channel_subid, [&](const CRMessageBasePtr& message) {
             ++count3;
             value3 = static_pointer_cast<TestMessage<1>>(message)->value_;
         });
 
         CRMessageBasePtr message1 = std::make_shared<TestMessage<1>>(100);
+        message1->SetChannelSubId(channel_subid);
         CRMessageBase::Dispatch(message1);
 
         node1.Process();
@@ -124,6 +137,7 @@ TEST(MessageTest, Subscribe) {
         EXPECT_EQ(value3, static_pointer_cast<TestMessage<1>>(message1)->value_);
 
         CRMessageBasePtr message2 = std::make_shared<TestMessage<1>>(200);
+        message2->SetChannelSubId(channel_subid);
         CRMessageBase::Dispatch(message2);
 
         node1.Process();
@@ -144,61 +158,92 @@ TEST(MessageTest, Subscribe) {
 }
 
 TEST(MessageTest, DeliveredTime) {
+    channel_subid_t               channel_subid     = 1;
+    channel_subid_t               channel_subid_2   = 2;
     constexpr cr_timestamp_nsec_t kDefaultTimestamp = 0;
 
     // Unknown/Unsent Message Type
-    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(/*channel_subid = */ 0), kDefaultTimestamp);
-    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(/*channel_subid = */ 0), kDefaultTimestamp);
-    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(/*channel_subid = */ 0), kDefaultTimestamp);
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid), kDefaultTimestamp);
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(channel_subid), kDefaultTimestamp);
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid), kDefaultTimestamp);
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid_2), kDefaultTimestamp);
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(channel_subid_2), kDefaultTimestamp);
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid_2), kDefaultTimestamp);
 
     SimpleTestNode node12(1);
     SimpleTestNode node23(1);
     SimpleTestNode node13(1);
 
-    node12.Subscribe<TestMessage<100>>(/*channel_subid = */ 0, [](auto&&) {});
-    node12.Subscribe<TestMessage<200>>(/*channel_subid = */ 0, [](auto&&) {});
+    node12.Subscribe<TestMessage<100>>(channel_subid, [](auto&&) {});
+    node12.Subscribe<TestMessage<200>>(channel_subid, [](auto&&) {});
 
-    node23.Subscribe<TestMessage<200>>(/*channel_subid = */ 0, [](auto&&) {});
-    node23.Subscribe<TestMessage<300>>(/*channel_subid = */ 0, [](auto&&) {});
+    node23.Subscribe<TestMessage<200>>(channel_subid, [](auto&&) {});
+    node23.Subscribe<TestMessage<300>>(channel_subid, [](auto&&) {});
 
-    node13.Subscribe<TestMessage<100>>(/*channel_subid = */ 0, [](auto&&) {});
-    node13.Subscribe<TestMessage<300>>(/*channel_subid = */ 0, [](auto&&) {});
+    node13.Subscribe<TestMessage<100>>(channel_subid, [](auto&&) {});
+    node13.Subscribe<TestMessage<300>>(channel_subid, [](auto&&) {});
 
     constexpr auto kRepeatTime = 5;
 
     for (int i = 0; i < kRepeatTime; ++i) {
         {
             auto start_time = GetSystemTimestampNsec();
-            CRMessageBase::Dispatch(std::make_shared<TestMessage<100>>(0));
+            auto message    = std::make_shared<TestMessage<100>>(0);
+            message->SetChannelSubId(channel_subid);
+            CRMessageBase::Dispatch(message);
             auto end_time = GetSystemTimestampNsec();
 
-            EXPECT_GE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(/*channel_subid = */ 0), start_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(/*channel_subid = */ 0), end_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(/*channel_subid = */ 0), start_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(/*channel_subid = */ 0), start_time);
+            EXPECT_GE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid), start_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid), end_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(channel_subid), start_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid), start_time);
         }
 
         {
             auto start_time = GetSystemTimestampNsec();
-            CRMessageBase::Dispatch(std::make_shared<TestMessage<200>>(0));
+            auto message    = std::make_shared<TestMessage<200>>(0);
+            message->SetChannelSubId(channel_subid);
+            CRMessageBase::Dispatch(message);
             auto end_time = GetSystemTimestampNsec();
 
-            EXPECT_GE(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(/*channel_subid = */ 0), start_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(/*channel_subid = */ 0), end_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(/*channel_subid = */ 0), start_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(/*channel_subid = */ 0), start_time);
+            EXPECT_GE(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(channel_subid), start_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid), end_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid), start_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid), start_time);
         }
 
         {
             auto start_time = GetSystemTimestampNsec();
-            CRMessageBase::Dispatch(std::make_shared<TestMessage<300>>(0));
+            auto message    = std::make_shared<TestMessage<300>>(0);
+            message->SetChannelSubId(channel_subid);
+            CRMessageBase::Dispatch(message);
             auto end_time = GetSystemTimestampNsec();
 
-            EXPECT_GE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(/*channel_subid = */ 0), start_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(/*channel_subid = */ 0), end_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(/*channel_subid = */ 0), start_time);
-            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(/*channel_subid = */ 0), start_time);
+            EXPECT_GE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid), start_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid), end_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid), start_time);
+            EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(channel_subid), start_time);
         }
+    }
+
+    // Other subchannels remain unchanged
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid_2), kDefaultTimestamp);
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(channel_subid_2), kDefaultTimestamp);
+    EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid_2), kDefaultTimestamp);
+
+    {
+        SimpleTestNode node(1);
+        node.Subscribe<TestMessage<100>>(channel_subid_2, [](auto&&) {});
+        auto start_time = GetSystemTimestampNsec();
+        auto message    = std::make_shared<TestMessage<100>>(0);
+        message->SetChannelSubId(channel_subid_2);
+        CRMessageBase::Dispatch(message);
+        auto end_time = GetSystemTimestampNsec();
+
+        // The second subchannel was updated while the first one remains unchanged
+        EXPECT_GE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid_2), start_time);
+        EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid_2), end_time);
+        EXPECT_LE(CRMessageBase::GetLatestDeliveredTime<TestMessage<100>>(channel_subid), start_time);
     }
 }
 

--- a/tests/node_test.cc
+++ b/tests/node_test.cc
@@ -69,57 +69,79 @@ template<int idx>
 struct TestMessage : public CRMessage<TestMessage<idx>> {};
 
 TEST(NodeTest, MultiQueueNode) {
-    CRMultiQueueNode<>            node(1);
-    constexpr size_t              kNumOfTopics = 4;
-    std::array<int, kNumOfTopics> received{0};
+    CRMultiQueueNode<> node(1);
+    constexpr size_t   kNumOfTopics     = 4;
+    constexpr size_t   kNumOfSubChannel = 4;
 
-    node.Subscribe<TestMessage<0>>(/*channel_subid = */ 0, [&received](const std::shared_ptr<TestMessage<0>>&) {
-        ++received[0];
-    });
-    node.Subscribe<TestMessage<1>>(/*channel_subid = */ 0, [&received](const std::shared_ptr<TestMessage<1>>&) {
-        ++received[1];
-    });
-    node.Subscribe<TestMessage<2>>(/*channel_subid = */ 0, [&received](const std::shared_ptr<TestMessage<2>>&) {
-        ++received[2];
-    });
-    node.Subscribe<TestMessage<3>>(/*channel_subid = */ 0, [&received](const std::shared_ptr<TestMessage<3>>&) {
-        ++received[3];
-    });
+    std::array<std::array<int, kNumOfSubChannel>, kNumOfTopics> received{};
 
-    {
-        constexpr int message_type_idx = 0;
-        auto          message          = std::make_shared<TestMessage<message_type_idx>>();
-        CRMessageBase::Dispatch(message);
-        node.MessageQueueMapper(message->GetChannelId())->PopAndProcess(false);
-
-        EXPECT_EQ(received[message_type_idx], 1);
+    for (size_t channel_subid = 0; channel_subid < kNumOfSubChannel; ++channel_subid) {
+        node.Subscribe<TestMessage<0>>(
+            channel_subid,
+            [&received, channel_subid](const std::shared_ptr<TestMessage<0>>&) { ++received[0][channel_subid]; });
+        node.Subscribe<TestMessage<1>>(
+            channel_subid,
+            [&received, channel_subid](const std::shared_ptr<TestMessage<1>>&) { ++received[1][channel_subid]; });
+        node.Subscribe<TestMessage<2>>(
+            channel_subid,
+            [&received, channel_subid](const std::shared_ptr<TestMessage<2>>&) { ++received[2][channel_subid]; });
+        node.Subscribe<TestMessage<3>>(
+            channel_subid,
+            [&received, channel_subid](const std::shared_ptr<TestMessage<3>>&) { ++received[3][channel_subid]; });
     }
 
-    {
-        constexpr int message_type_idx = 1;
-        auto          message          = std::make_shared<TestMessage<message_type_idx>>();
-        CRMessageBase::Dispatch(message);
-        node.MessageQueueMapper(message->GetChannelId())->PopAndProcess(false);
+    for (size_t channel_subid = 0; channel_subid < kNumOfSubChannel; ++channel_subid) {
+        {
+            constexpr int message_type_idx = 0;
+            auto          message          = std::make_shared<TestMessage<message_type_idx>>();
+            message->SetChannelSubId(channel_subid);
 
-        EXPECT_EQ(received[message_type_idx], 1);
-    }
+            EXPECT_EQ(received[message_type_idx][channel_subid], 0);
 
-    {
-        constexpr int message_type_idx = 2;
-        auto          message          = std::make_shared<TestMessage<message_type_idx>>();
-        CRMessageBase::Dispatch(message);
-        node.MessageQueueMapper(message->GetChannelId())->PopAndProcess(false);
+            CRMessageBase::Dispatch(message);
+            node.MessageQueueMapper(message->GetChannelId())->PopAndProcess(false);
 
-        EXPECT_EQ(received[message_type_idx], 1);
-    }
+            EXPECT_EQ(received[message_type_idx][channel_subid], 1);
+        }
 
-    {
-        constexpr int message_type_idx = 3;
-        auto          message          = std::make_shared<TestMessage<message_type_idx>>();
-        CRMessageBase::Dispatch(message);
-        node.MessageQueueMapper(message->GetChannelId())->PopAndProcess(false);
+        {
+            constexpr int message_type_idx = 1;
+            auto          message          = std::make_shared<TestMessage<message_type_idx>>();
+            message->SetChannelSubId(channel_subid);
 
-        EXPECT_EQ(received[message_type_idx], 1);
+            EXPECT_EQ(received[message_type_idx][channel_subid], 0);
+
+            CRMessageBase::Dispatch(message);
+            node.MessageQueueMapper(message->GetChannelId())->PopAndProcess(false);
+
+            EXPECT_EQ(received[message_type_idx][channel_subid], 1);
+        }
+
+        {
+            constexpr int message_type_idx = 2;
+            auto          message          = std::make_shared<TestMessage<message_type_idx>>();
+            message->SetChannelSubId(channel_subid);
+
+            EXPECT_EQ(received[message_type_idx][channel_subid], 0);
+
+            CRMessageBase::Dispatch(message);
+            node.MessageQueueMapper(message->GetChannelId())->PopAndProcess(false);
+
+            EXPECT_EQ(received[message_type_idx][channel_subid], 1);
+        }
+
+        {
+            constexpr int message_type_idx = 3;
+            auto          message          = std::make_shared<TestMessage<message_type_idx>>();
+            message->SetChannelSubId(channel_subid);
+
+            EXPECT_EQ(received[message_type_idx][channel_subid], 0);
+
+            CRMessageBase::Dispatch(message);
+            node.MessageQueueMapper(message->GetChannelId())->PopAndProcess(false);
+
+            EXPECT_EQ(received[message_type_idx][channel_subid], 1);
+        }
     }
 }
 

--- a/tests/rr_runner_test.cc
+++ b/tests/rr_runner_test.cc
@@ -1,3 +1,4 @@
+#include "cris/core/message/base.h"
 #include "cris/core/node/multi_queue_node.h"
 #include "cris/core/node/single_queue_node.h"
 #include "cris/core/node_runner/runner.h"
@@ -123,19 +124,21 @@ TEST_F(RRRunnerTest, MultiQueueMultiThread) {
 }
 
 void RRRunnerTest::TestImpl(CRNodeBase* node, CRNodeRunnerBase* node_runner) {
+    constexpr CRMessageBase::channel_subid_t kChannelSubIDForTest = 1;
+
     for (size_t i = 0; i < kMessageTypeNum; ++i) {
         for (size_t j = 0; j < kMessageNum; ++j) {
             EXPECT_EQ(count_[i][j], 0);
         }
     }
 
-    node->Subscribe<MessageForTest<0>>(/*channel_subid = */ 0, &RRRunnerTest::MessageProcessorForTest<0>);
-    node->Subscribe<MessageForTest<1>>(/*channel_subid = */ 0, &RRRunnerTest::MessageProcessorForTest<1>);
-    node->Subscribe<MessageForTest<2>>(/*channel_subid = */ 0, &RRRunnerTest::MessageProcessorForTest<2>);
-    node->Subscribe<MessageForTest<3>>(/*channel_subid = */ 0, &RRRunnerTest::MessageProcessorForTest<3>);
-    node->Subscribe<MessageForTest<4>>(/*channel_subid = */ 0, &RRRunnerTest::MessageProcessorForTest<4>);
-    node->Subscribe<MessageForTest<5>>(/*channel_subid = */ 0, &RRRunnerTest::MessageProcessorForTest<5>);
-    node->Subscribe<MessageForTest<6>>(/*channel_subid = */ 0, &RRRunnerTest::MessageProcessorForTest<6>);
+    node->Subscribe<MessageForTest<0>>(kChannelSubIDForTest, &RRRunnerTest::MessageProcessorForTest<0>);
+    node->Subscribe<MessageForTest<1>>(kChannelSubIDForTest, &RRRunnerTest::MessageProcessorForTest<1>);
+    node->Subscribe<MessageForTest<2>>(kChannelSubIDForTest, &RRRunnerTest::MessageProcessorForTest<2>);
+    node->Subscribe<MessageForTest<3>>(kChannelSubIDForTest, &RRRunnerTest::MessageProcessorForTest<3>);
+    node->Subscribe<MessageForTest<4>>(kChannelSubIDForTest, &RRRunnerTest::MessageProcessorForTest<4>);
+    node->Subscribe<MessageForTest<5>>(kChannelSubIDForTest, &RRRunnerTest::MessageProcessorForTest<5>);
+    node->Subscribe<MessageForTest<6>>(kChannelSubIDForTest, &RRRunnerTest::MessageProcessorForTest<6>);
     node_runner->Run();
 
     for (size_t i = 0; i < kMessageNum; ++i) {
@@ -147,12 +150,19 @@ void RRRunnerTest::TestImpl(CRNodeBase* node, CRNodeRunnerBase* node_runner) {
         auto message5 = std::make_shared<MessageForTest<5>>(i, this);
         auto message6 = std::make_shared<MessageForTest<6>>(i, this);
 
+        message0->SetChannelSubId(kChannelSubIDForTest);
         CRMessageBase::Dispatch(message0);
+        message1->SetChannelSubId(kChannelSubIDForTest);
         CRMessageBase::Dispatch(message1);
+        message2->SetChannelSubId(kChannelSubIDForTest);
         CRMessageBase::Dispatch(message2);
+        message3->SetChannelSubId(kChannelSubIDForTest);
         CRMessageBase::Dispatch(message3);
+        message4->SetChannelSubId(kChannelSubIDForTest);
         CRMessageBase::Dispatch(message4);
+        message5->SetChannelSubId(kChannelSubIDForTest);
         CRMessageBase::Dispatch(message5);
+        message6->SetChannelSubId(kChannelSubIDForTest);
         CRMessageBase::Dispatch(message6);
     }
 


### PR DESCRIPTION
Before this commit, message subscriptions are purely type-based,
but sometimes the subscriptions have to be determined by runtime
information (e.g., reading from config files). That is why we introduce
channel sub-ID.