### PR TITLE
GetReport Returns an Empty Report when Profiling Disabled

### DIFF
--- a/src/timer/timer_disable.cc
+++ b/src/timer/timer_disable.cc
@@ -58,7 +58,7 @@ TimerSession TimerSection::StartTimerSession() {
 }
 
 std::unique_ptr<TimerReport> TimerSection::GetReport(bool /* recursive */) {
-    return {};
+    return std::make_unique<TimerReport>();
 }
 
 TimerSection* TimerSection::SubSection(const std::string& /* name */) {


### PR DESCRIPTION
The result of GetReport can be safely used no matter if prof
is enabled.