### PR TITLE
Generate ccache wrapper scripts instead of symlink

### DIFF
--- a/scripts/codebase_utils.sh
+++ b/scripts/codebase_utils.sh
@@ -13,7 +13,6 @@ export CRIS_CODE_DIRS="$(sed 's/^[[:space:]]*//' <<< "
 " | grep '[^[:space:]]')"
 
 function bazel_common_all () {
-    # Need to set PATH instead of CC because Bazel does not
-    # like '/'s in the CC value.
+    # Need to set PATH instead of CC because Bazel does not like '/'s in the CC value.
     PATH="$CR_CCACHE_CC_DIR:$PATH" bazel "$@" '//...'
 }

--- a/scripts/codebase_utils.sh
+++ b/scripts/codebase_utils.sh
@@ -13,5 +13,6 @@ export CRIS_CODE_DIRS="$(sed 's/^[[:space:]]*//' <<< "
 " | grep '[^[:space:]]')"
 
 function bazel_common_all () {
-    bazel "$@" '//...'
+    echo "$CR_CCACHE_CC_DIR:$PATH"
+    PATH="$CR_CCACHE_CC_DIR:$PATH" bazel "$@" '//...'
 }

--- a/scripts/codebase_utils.sh
+++ b/scripts/codebase_utils.sh
@@ -14,5 +14,5 @@ export CRIS_CODE_DIRS="$(sed 's/^[[:space:]]*//' <<< "
 
 function bazel_common_all () {
     # Need to set PATH instead of CC because Bazel does not like '/'s in the CC value.
-    CC="$(basename "$CC")" PATH="$CR_CCACHE_CC_DIR:$PATH" bazel "$@" '//...'
+    PATH="$(dirname "$CC"):$PATH" CC="$(basename "$CC")" bazel "$@" '//...'
 }

--- a/scripts/codebase_utils.sh
+++ b/scripts/codebase_utils.sh
@@ -14,5 +14,5 @@ export CRIS_CODE_DIRS="$(sed 's/^[[:space:]]*//' <<< "
 
 function bazel_common_all () {
     # Need to set PATH instead of CC because Bazel does not like '/'s in the CC value.
-    PATH="$CR_CCACHE_CC_DIR:$PATH" bazel "$@" '//...'
+    CC="$(basename "$CC")" PATH="$CR_CCACHE_CC_DIR:$PATH" bazel "$@" '//...'
 }

--- a/scripts/codebase_utils.sh
+++ b/scripts/codebase_utils.sh
@@ -13,6 +13,7 @@ export CRIS_CODE_DIRS="$(sed 's/^[[:space:]]*//' <<< "
 " | grep '[^[:space:]]')"
 
 function bazel_common_all () {
-    echo "$CR_CCACHE_CC_DIR:$PATH"
+    # Need to set PATH instead of CC because Bazel does not
+    # like '/'s in the CC value.
     PATH="$CR_CCACHE_CC_DIR:$PATH" bazel "$@" '//...'
 }

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -14,18 +14,17 @@ pushd "$(dirname "$0")/.."
 if which ccache >/dev/null 2>&1 && ([ -d 'run' ] && [ -w 'run' ] || [ -w '.' ]); then
     rm -rf 'run/toolchain'
     mkdir -p 'run/toolchain'
-    export CR_CCACHE_CC_DIR="$( realpath -e "run/toolchain")"
+    export CR_CCACHE_CC_DIR="$(realpath -e "run/toolchain")"
 
     for compiler in $CC $CXX; do
         # Bazel may dereference the ccache symlink, so we use wrapper scripts instead.
         # See https://github.com/bazelbuild/rules_cc/issues/130
-        cat << EOF > "$CR_CCACHE_CC_DIR/$compiler"
-#!/bin/bash
-$(which ccache) $(which $compiler) \$@
-EOF
+        cat << ____________EOF | sed 's/^            //' > "$CR_CCACHE_CC_DIR/$compiler"
+            #!/bin/bash
+            '$(which ccache)' '$(which $compiler)' "\$@"
+____________EOF
+        chmod +x "$CR_CCACHE_CC_DIR/$compiler"
     done
-
-    chmod +x "$CR_CCACHE_CC_DIR"/*
 fi
 
 popd

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -16,14 +16,14 @@ if which ccache >/dev/null 2>&1 && ([ -d 'run' ] && [ -w 'run' ] || [ -w '.' ]);
     mkdir -p 'run/toolchain'
     export CR_CCACHE_CC_DIR="$(realpath -e "run/toolchain")"
 
-    for compiler in $CC $CXX; do
+    for compiler in "$CC"; do
         # Bazel may dereference the ccache symlink, so we use wrapper scripts instead.
         # See https://github.com/bazelbuild/rules_cc/issues/130
-        cat << ____________EOF | sed 's/^            //' > "$CR_CCACHE_CC_DIR/$compiler"
+        cat << ____________EOF | sed 's/^            //' > "$CR_CCACHE_CC_DIR/$(basename "$compiler")"
             #!/bin/bash
             '$(which ccache)' '$(which $compiler)' "\$@"
 ____________EOF
-        chmod +x "$CR_CCACHE_CC_DIR/$compiler"
+        chmod +x "$CR_CCACHE_CC_DIR/$(basename "$compiler")"
     done
 fi
 

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -14,16 +14,19 @@ pushd "$(dirname "$0")/.."
 if which ccache >/dev/null 2>&1 && ([ -d 'run' ] && [ -w 'run' ] || [ -w '.' ]); then
     rm -rf 'run/toolchain'
     mkdir -p 'run/toolchain'
-    export CR_CCACHE_CC_DIR="$(realpath -e "run/toolchain")"
+    CR_CCACHE_CC_DIR="$(realpath -e "run/toolchain")"
 
-    for compiler in "$CC"; do
+    for compiler_varname in "CC"; do
+        compiler=$(eval echo "\$$compiler_varname")
+        ccache_wrapper="$CR_CCACHE_CC_DIR/$(basename "$compiler")"
         # Bazel may dereference the ccache symlink, so we use wrapper scripts instead.
         # See https://github.com/bazelbuild/rules_cc/issues/130
-        cat << ____________EOF | sed 's/^            //' > "$CR_CCACHE_CC_DIR/$(basename "$compiler")"
+        cat << ____________EOF | sed 's/^            //' > "$ccache_wrapper"
             #!/bin/bash
-            '$(which ccache)' '$(which $compiler)' "\$@"
+            '$(which ccache)' '$(which "$compiler")' "\$@"
 ____________EOF
-        chmod +x "$CR_CCACHE_CC_DIR/$(basename "$compiler")"
+        chmod +x "$ccache_wrapper"
+        eval "export $compiler_varname='$ccache_wrapper'"
     done
 fi
 

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -17,7 +17,7 @@ if which ccache >/dev/null 2>&1 && ([ -d 'run' ] && [ -w 'run' ] || [ -w '.' ]);
     CR_CCACHE_CC_DIR="$(realpath -e "run/toolchain")"
 
     for compiler_varname in "CC"; do
-        compiler=$(eval echo "\$$compiler_varname")
+        compiler="$(eval echo "\$$compiler_varname")"
         ccache_wrapper="$CR_CCACHE_CC_DIR/$(basename "$compiler")"
         # Bazel may dereference the ccache symlink, so we use wrapper scripts instead.
         # See https://github.com/bazelbuild/rules_cc/issues/130

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -17,6 +17,8 @@ if which ccache >/dev/null 2>&1 && ([ -d 'run' ] && [ -w 'run' ] || [ -w '.' ]);
     export CR_CCACHE_CC_DIR="$( realpath -e "run/toolchain")"
 
     for compiler in $CC $CXX; do
+        # Bazel may dereference the ccache symlink, so we use wrapper scripts instead.
+        # See https://github.com/bazelbuild/rules_cc/issues/130
         cat << EOF > "$CR_CCACHE_CC_DIR/$compiler"
 #!/bin/bash
 $(which ccache) $(which $compiler) \$@

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -14,10 +14,16 @@ pushd "$(dirname "$0")/.."
 if which ccache >/dev/null 2>&1 && ([ -d 'run' ] && [ -w 'run' ] || [ -w '.' ]); then
     rm -rf 'run/toolchain'
     mkdir -p 'run/toolchain'
-    ln -sf "$(which ccache)" "run/toolchain/$CC"
-    ln -sf "$(which ccache)" "run/toolchain/$CXX"
-    export CC="$( realpath -e "run/toolchain")/$CC"
-    export CXX="$(realpath -e "run/toolchain")/$CXX"
+    NEW_CC_DIR="$( realpath -e "run/toolchain")"
+
+    for compiler in $CC $CXX; do
+        echo """#!/bin/bash
+$(which ccache) $(which $compiler) \$@
+        """ > "$NEW_CC_DIR"/$compiler
+    done
+
+    chmod +x "$NEW_CC_DIR"/*
+    export PATH="$NEW_CC_DIR":$PATH
 fi
 
 popd

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -14,16 +14,16 @@ pushd "$(dirname "$0")/.."
 if which ccache >/dev/null 2>&1 && ([ -d 'run' ] && [ -w 'run' ] || [ -w '.' ]); then
     rm -rf 'run/toolchain'
     mkdir -p 'run/toolchain'
-    NEW_CC_DIR="$( realpath -e "run/toolchain")"
+    export CR_CCACHE_CC_DIR="$( realpath -e "run/toolchain")"
 
     for compiler in $CC $CXX; do
-        echo """#!/bin/bash
+        cat << EOF > "$CR_CCACHE_CC_DIR/$compiler"
+#!/bin/bash
 $(which ccache) $(which $compiler) \$@
-        """ > "$NEW_CC_DIR"/$compiler
+EOF
     done
 
-    chmod +x "$NEW_CC_DIR"/*
-    export PATH="$NEW_CC_DIR":$PATH
+    chmod +x "$CR_CCACHE_CC_DIR"/*
 fi
 
 popd


### PR DESCRIPTION
Tested with Bazel 5.2. It is a workaround for issue
https://github.com/bazelbuild/rules_cc/issues/130