### PR TITLE
Switch from libunwind to boost stacktrace

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,8 +9,11 @@ cris_cc_library (
     include_prefix = "cris/core",
     strip_include_prefix = "includes",
     hdrs = glob(["includes/**/*.h"]),
+    copts = [
+        "-DBOOST_STACKTRACE_USE_ADDR2LINE",
+    ],
     linkopts = [
-        "-lunwind",
+        "-ldl",
     ],
     deps = [
         "@com_github_google_glog//:glog",


### PR DESCRIPTION
libunwind-dev conflict with libc++-14-dev, and the header files
libunwind-14-dev are in /usr/include/libunwind and they are out of
the compiler search path.