### PR TITLE
Set C++ Standard Globally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 build --config="_zlib64"
+build --cxxopt="-std=c++20"
 build -c opt
 
 build:_zlib64 --copt="-D_FILE_OFFSET_BITS=64"

--- a/bazel/rules.bzl
+++ b/bazel/rules.bzl
@@ -4,7 +4,6 @@ CRIS_CXXOPTS = [
     "-Werror",
     "-Wextra",
     "-g3",
-    "-std=c++20",
     "-fno-sanitize-recover=all",
 ]
 


### PR DESCRIPTION
The C++ standard that we use should be consistent in compiling both
our code and 3rd party code, because there may be cpp standard check
and the behavior in the header (compiled with our code) and the cpp
files (compiled as 3rd party) must be consistent.