### PR TITLE
Subscribe message with strand

### DIFF
--- a/src/sched/job_runner.cc
+++ b/src/sched/job_runner.cc
@@ -215,7 +215,7 @@ bool JobRunner::AddJob(job_t&& job, std::size_t scheduler_hint) {
 }
 
 bool JobRunner::AddJob(job_t&& job, std::shared_ptr<JobRunnerStrand> strand) {
-    return strand->AddJob(std::move(job));
+    return strand ? strand->AddJob(std::move(job)) : AddJob(std::move(job));
 }
 
 bool JobRunner::Steal() {

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -21,6 +21,12 @@ cris_cc_test (
 cris_cc_test (
     name = "node_test",
     srcs = ["node_test.cc"],
+    env = {
+        "TSAN_OPTIONS": "suppressions=$(execpath job_runner_tsan_suppressions)",
+    },
+    data = [
+        ":job_runner_tsan_suppressions",
+    ],
     deps = [
         "//:msg",
         "@gtest//:gtest_main",
@@ -37,18 +43,18 @@ cris_cc_test (
 )
 
 filegroup(
-    name = "job_runner_test_tsan_suppressions",
-    srcs = ["job_runner_test_tsan_suppressions.txt"],
+    name = "job_runner_tsan_suppressions",
+    srcs = ["job_runner_tsan_suppressions.txt"],
 )
 
 cris_cc_test (
     name = "job_runner_test",
     srcs = ["job_runner_test.cc"],
     env = {
-        "TSAN_OPTIONS": "suppressions=$(execpath job_runner_test_tsan_suppressions)",
+        "TSAN_OPTIONS": "suppressions=$(execpath job_runner_tsan_suppressions)",
     },
     data = [
-        ":job_runner_test_tsan_suppressions",
+        ":job_runner_tsan_suppressions",
     ],
     deps = [
         "//:sched",

--- a/tests/job_runner_tsan_suppressions.txt
+++ b/tests/job_runner_tsan_suppressions.txt
@@ -1,3 +1,5 @@
 # Boost lockfree queue triggers the data race warning, which is a known issue.
 # https://github.com/boostorg/lockfree/issues/78
 race:boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
+race:boost/lockfree/detail/copy_payload.hpp
+race:boost/lockfree/queue.hpp

--- a/tests/node_test.cc
+++ b/tests/node_test.cc
@@ -2,6 +2,7 @@
 
 #include "gtest/gtest.h"
 
+#include <array>
 #include <condition_variable>
 #include <cstddef>
 #include <memory>
@@ -267,8 +268,8 @@ TEST(NodeTest, StrandSubscriber) {
 
     std::mutex                                cv_mutex;
     std::condition_variable                   cv;
-    std::array<std::size_t, kNumOfSubChannel> channel_counter{0};
-    std::array<bool, kNumOfSubChannel>        complete{0};
+    std::array<std::size_t, kNumOfSubChannel> channel_counter{};
+    std::array<bool, kNumOfSubChannel>        complete{};
 
     for (std::size_t channel_subid = 0; channel_subid < kNumOfSubChannel; ++channel_subid) {
         subscriber.Subscribe<TestMessageType>(

--- a/tests/node_test.cc
+++ b/tests/node_test.cc
@@ -5,6 +5,7 @@
 #include <array>
 #include <condition_variable>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <numeric>
@@ -36,7 +37,7 @@ TEST(NodeTest, Basic) {
         auto   runner = JobRunner::MakeJobRunner(JobRunner::Config{});
         subscriber.SetRunner(runner);
 
-        auto cv_mutex = std::make_shared<std::mutex>();
+        auto cv_mtx   = std::make_shared<std::mutex>();
         auto cv       = std::make_shared<std::condition_variable>();
         auto received = std::make_shared<bool>(false);
 
@@ -50,8 +51,8 @@ TEST(NodeTest, Basic) {
 
         subscriber.Subscribe<TestMessageType>(
             channel_subid,
-            [message_value, cv_mutex, cv, received](const std::shared_ptr<TestMessageType>& msg) {
-                std::unique_lock cv_lock(*cv_mutex);
+            [message_value, cv_mtx, cv, received](const std::shared_ptr<TestMessageType>& msg) {
+                std::unique_lock cv_lck(*cv_mtx);
                 EXPECT_EQ(msg->value_, message_value);
                 *received = true;
                 cv->notify_all();
@@ -62,8 +63,8 @@ TEST(NodeTest, Basic) {
 
         publisher.Publish(channel_subid, std::make_shared<TestMessageType>(message_value));
 
-        std::unique_lock cv_lock(*cv_mutex);
-        cv->wait(cv_lock, [received]() { return *received; });
+        std::unique_lock cv_lck(*cv_mtx);
+        cv->wait(cv_lck, [received]() { return *received; });
     }
 
     // Publishing while nobody subscribing.
@@ -83,37 +84,37 @@ TEST(NodeTest, MultipleChannels) {
         std::array<std::array<int, kNumOfSubChannel>, kNumOfMsgTypes> data_{};
     };
 
-    auto cv_mutex = std::make_shared<std::mutex>();
-    auto cv       = std::make_shared<std::condition_variable>();
+    auto cv_mtx = std::make_shared<std::mutex>();
+    auto cv     = std::make_shared<std::condition_variable>();
 
     auto received = std::make_shared<Received>();
 
     for (std::size_t channel_subid = 0; channel_subid < kNumOfSubChannel; ++channel_subid) {
         subscriber.Subscribe<TestMessage<0>>(
             channel_subid,
-            [received, channel_subid, cv_mutex, cv](const std::shared_ptr<TestMessage<0>>& msg) {
-                std::unique_lock cv_lock(*cv_mutex);
+            [received, channel_subid, cv_mtx, cv](const std::shared_ptr<TestMessage<0>>& msg) {
+                std::unique_lock cv_lck(*cv_mtx);
                 received->data_[0][channel_subid] = msg->value_;
                 cv->notify_all();
             });
         subscriber.Subscribe<TestMessage<1>>(
             channel_subid,
-            [received, channel_subid, cv_mutex, cv](const std::shared_ptr<TestMessage<1>>& msg) {
-                std::unique_lock cv_lock(*cv_mutex);
+            [received, channel_subid, cv_mtx, cv](const std::shared_ptr<TestMessage<1>>& msg) {
+                std::unique_lock cv_lck(*cv_mtx);
                 received->data_[1][channel_subid] = msg->value_;
                 cv->notify_all();
             });
         subscriber.Subscribe<TestMessage<2>>(
             channel_subid,
-            [received, channel_subid, cv_mutex, cv](const std::shared_ptr<TestMessage<2>>& msg) {
-                std::unique_lock cv_lock(*cv_mutex);
+            [received, channel_subid, cv_mtx, cv](const std::shared_ptr<TestMessage<2>>& msg) {
+                std::unique_lock cv_lck(*cv_mtx);
                 received->data_[2][channel_subid] = msg->value_;
                 cv->notify_all();
             });
         subscriber.Subscribe<TestMessage<3>>(
             channel_subid,
-            [received, channel_subid, cv_mutex, cv](const std::shared_ptr<TestMessage<3>>& msg) {
-                std::unique_lock cv_lock(*cv_mutex);
+            [received, channel_subid, cv_mtx, cv](const std::shared_ptr<TestMessage<3>>& msg) {
+                std::unique_lock cv_lck(*cv_mtx);
                 received->data_[3][channel_subid] = msg->value_;
                 cv->notify_all();
             });
@@ -128,8 +129,8 @@ TEST(NodeTest, MultipleChannels) {
 
             publisher.Publish(channel_subid, std::make_shared<TestMessage<message_type_idx>>(message_value));
 
-            std::unique_lock cv_lock(*cv_mutex);
-            cv->wait(cv_lock, [received, channel_subid]() {
+            std::unique_lock cv_lck(*cv_mtx);
+            cv->wait(cv_lck, [received, channel_subid]() {
                 return received->data_[message_type_idx][channel_subid] != 0;
             });
 
@@ -144,8 +145,8 @@ TEST(NodeTest, MultipleChannels) {
 
             publisher.Publish(channel_subid, std::make_shared<TestMessage<message_type_idx>>(message_value));
 
-            std::unique_lock cv_lock(*cv_mutex);
-            cv->wait(cv_lock, [received, channel_subid]() {
+            std::unique_lock cv_lck(*cv_mtx);
+            cv->wait(cv_lck, [received, channel_subid]() {
                 return received->data_[message_type_idx][channel_subid] != 0;
             });
 
@@ -160,8 +161,8 @@ TEST(NodeTest, MultipleChannels) {
 
             publisher.Publish(channel_subid, std::make_shared<TestMessage<message_type_idx>>(message_value));
 
-            std::unique_lock cv_lock(*cv_mutex);
-            cv->wait(cv_lock, [received, channel_subid]() {
+            std::unique_lock cv_lck(*cv_mtx);
+            cv->wait(cv_lck, [received, channel_subid]() {
                 return received->data_[message_type_idx][channel_subid] != 0;
             });
 
@@ -176,8 +177,8 @@ TEST(NodeTest, MultipleChannels) {
 
             publisher.Publish(channel_subid, std::make_shared<TestMessage<message_type_idx>>(message_value));
 
-            std::unique_lock cv_lock(*cv_mutex);
-            cv->wait(cv_lock, [received, channel_subid]() {
+            std::unique_lock cv_lck(*cv_mtx);
+            cv->wait(cv_lck, [received, channel_subid]() {
                 return received->data_[message_type_idx][channel_subid] != 0;
             });
 
@@ -204,16 +205,16 @@ TEST(NodeTest, MultipleSubscriber) {
 
     auto runner = JobRunner::MakeJobRunner(JobRunner::Config{});
 
-    auto cv_mutex = std::make_shared<std::mutex>();
-    auto cv       = std::make_shared<std::condition_variable>();
+    auto cv_mtx = std::make_shared<std::mutex>();
+    auto cv     = std::make_shared<std::condition_variable>();
 
     for (std::size_t i = 0; i < kNumOfSubscribers; ++i) {
         auto subscriber = std::make_unique<Subscriber>();
         subscriber->SetRunner(runner);
         subscriber->Subscribe<TestMessageType>(
             channel_subid,
-            [subscriber = subscriber.get(), cv_mutex, cv](const std::shared_ptr<TestMessageType>& message) {
-                std::unique_lock cv_lock(*cv_mutex);
+            [subscriber = subscriber.get(), cv_mtx, cv](const std::shared_ptr<TestMessageType>& message) {
+                std::unique_lock cv_lck(*cv_mtx);
                 subscriber->received_ = message->value_;
                 cv->notify_all();
             });
@@ -227,10 +228,10 @@ TEST(NodeTest, MultipleSubscriber) {
             subscriber->received_ = 0;
         }
         publisher.Publish(channel_subid, std::make_shared<TestMessageType>(message_value));
-        std::unique_lock lock(*cv_mutex);
+        std::unique_lock lck(*cv_mtx);
 
         for (auto& subscriber : subscribers) {
-            cv->wait(lock, [subscriber = subscriber.get()]() { return subscriber->received_ != 0; });
+            cv->wait(lck, [subscriber = subscriber.get()]() { return subscriber->received_ != 0; });
             EXPECT_EQ(subscriber->received_, message_value);
         }
     }
@@ -242,10 +243,10 @@ TEST(NodeTest, MultipleSubscriber) {
             subscriber->received_ = 0;
         }
         publisher.Publish(channel_subid, std::make_shared<TestMessageType>(message_value));
-        std::unique_lock lock(*cv_mutex);
+        std::unique_lock lck(*cv_mtx);
 
         for (auto& subscriber : subscribers) {
-            cv->wait(lock, [subscriber = subscriber.get()]() { return subscriber->received_ != 0; });
+            cv->wait(lck, [subscriber = subscriber.get()]() { return subscriber->received_ != 0; });
             EXPECT_EQ(subscriber->received_, message_value);
         }
     }
@@ -266,7 +267,7 @@ TEST(NodeTest, StrandSubscriber) {
     });
     subscriber.SetRunner(runner);
 
-    std::mutex                                cv_mutex;
+    std::mutex                                cv_mtx;
     std::condition_variable                   cv;
     std::array<std::size_t, kNumOfSubChannel> channel_counter{};
     std::array<bool, kNumOfSubChannel>        complete{};
@@ -274,11 +275,11 @@ TEST(NodeTest, StrandSubscriber) {
     for (std::size_t channel_subid = 0; channel_subid < kNumOfSubChannel; ++channel_subid) {
         subscriber.Subscribe<TestMessageType>(
             channel_subid,
-            [&counter = channel_counter[channel_subid], &complete = complete[channel_subid], &cv_mutex, &cv](
+            [&counter = channel_counter[channel_subid], &complete = complete[channel_subid], &cv_mtx, &cv](
                 const std::shared_ptr<TestMessageType>& message) {
                 EXPECT_EQ(counter++, message->value_);
                 if (counter == kMessageNumber) {
-                    std::unique_lock cv_lock(cv_mutex);
+                    std::unique_lock cv_lck(cv_mtx);
                     complete = true;
                     cv.notify_all();
                 }
@@ -292,8 +293,8 @@ TEST(NodeTest, StrandSubscriber) {
         }
     }
 
-    std::unique_lock cv_lock(cv_mutex);
-    cv.wait(cv_lock, [&complete]() {
+    std::unique_lock cv_lck(cv_mtx);
+    cv.wait(cv_lck, [&complete]() {
         return std::reduce(complete.begin(), complete.end(), true, std::logical_and<void>());
     });
 }


### PR DESCRIPTION
Some messages must be handled sequentially, so I add a few more subscription functions to support that.