### PR TITLE
Passing Runner in the Node Constructor

### DIFF
--- a/src/msg/node.h
+++ b/src/msg/node.h
@@ -25,9 +25,13 @@ class CRNode {
     using job_t           = JobRunner::job_t;
     using strand_ptr_t    = std::shared_ptr<JobRunnerStrand>;
 
-    explicit CRNode() : CRNode("noname") {}
+    explicit CRNode() : CRNode("noname", nullptr) {}
 
-    explicit CRNode(std::string name) : name_(std::move(name)) {}
+    explicit CRNode(std::string name) : CRNode(std::move(name), nullptr) {}
+
+    explicit CRNode(std::shared_ptr<JobRunner> runner) : CRNode("noname", std::move(runner)) {}
+
+    explicit CRNode(std::string name, std::shared_ptr<JobRunner> runner);
 
     virtual ~CRNode();
 
@@ -37,8 +41,6 @@ class CRNode {
     virtual void StopMainLoop() {}
 
     std::string GetName() const { return name_; }
-
-    void SetRunner(std::shared_ptr<JobRunner> runner);
 
     bool AddJobToRunner(job_t&& job, strand_ptr_t strand);
 
@@ -85,6 +87,7 @@ class CRNode {
         strand_ptr_t                                   strand);
 
     std::string               name_;
+    bool                      can_subscribe_{false};
     std::vector<channel_id_t> subscribed_;
     callback_map_t            callbacks_;
     std::weak_ptr<JobRunner>  runner_weak_;

--- a/tests/message_test.cc
+++ b/tests/message_test.cc
@@ -1,6 +1,7 @@
 #include "cris/core/msg/message.h"
 
 #include "cris/core/msg/node.h"
+#include "cris/core/sched/job_runner.h"
 
 #include "gtest/gtest.h"
 
@@ -46,9 +47,10 @@ TEST(MessageTest, DeliveredTime) {
     EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<200>>(channel_subid_2), kDefaultTimestamp);
     EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid_2), kDefaultTimestamp);
 
-    CRNode node12;
-    CRNode node23;
-    CRNode node13;
+    auto   runner = JobRunner::MakeJobRunner({});
+    CRNode node12(runner);
+    CRNode node23(runner);
+    CRNode node13(runner);
 
     node12.Subscribe<TestMessage<100>>(channel_subid, [](auto&&) {});
     node12.Subscribe<TestMessage<200>>(channel_subid, [](auto&&) {});
@@ -102,7 +104,7 @@ TEST(MessageTest, DeliveredTime) {
     EXPECT_EQ(CRMessageBase::GetLatestDeliveredTime<TestMessage<300>>(channel_subid_2), kDefaultTimestamp);
 
     {
-        CRNode node;
+        CRNode node(runner);
         node.Subscribe<TestMessage<100>>(channel_subid_2, [](auto&&) {});
         auto start_time = GetSystemTimestampNsec();
         publisher.Publish(channel_subid_2, std::make_shared<TestMessage<100>>(0));

--- a/tests/node_test.cc
+++ b/tests/node_test.cc
@@ -33,9 +33,8 @@ TEST(NodeTest, Basic) {
     publisher.Publish(channel_subid, std::make_shared<TestMessageType>(1));
 
     {
-        CRNode subscriber;
         auto   runner = JobRunner::MakeJobRunner(JobRunner::Config{});
-        subscriber.SetRunner(runner);
+        CRNode subscriber(runner);
 
         auto cv_mtx   = std::make_shared<std::mutex>();
         auto cv       = std::make_shared<std::condition_variable>();
@@ -75,10 +74,9 @@ TEST(NodeTest, MultipleChannels) {
     constexpr std::size_t kNumOfMsgTypes   = 4;
     constexpr std::size_t kNumOfSubChannel = 4;
 
-    CRNode publisher;
-    CRNode subscriber;
     auto   runner = JobRunner::MakeJobRunner(JobRunner::Config{});
-    subscriber.SetRunner(runner);
+    CRNode publisher;
+    CRNode subscriber(runner);
 
     struct Received {
         std::array<std::array<int, kNumOfSubChannel>, kNumOfMsgTypes> data_{};
@@ -209,8 +207,7 @@ TEST(NodeTest, MultipleSubscriber) {
     auto cv     = std::make_shared<std::condition_variable>();
 
     for (std::size_t i = 0; i < kNumOfSubscribers; ++i) {
-        auto subscriber = std::make_unique<Subscriber>();
-        subscriber->SetRunner(runner);
+        auto subscriber = std::make_unique<Subscriber>(runner);
         subscriber->Subscribe<TestMessageType>(
             channel_subid,
             [subscriber = subscriber.get(), cv_mtx, cv](const std::shared_ptr<TestMessageType>& message) {
@@ -259,13 +256,12 @@ TEST(NodeTest, StrandSubscriber) {
 
     using TestMessageType = TestMessage<11>;
 
-    CRNode publisher;
-    CRNode subscriber;
-
     auto runner = JobRunner::MakeJobRunner(JobRunner::Config{
         .thread_num_ = kThreadNum,
     });
-    subscriber.SetRunner(runner);
+
+    CRNode publisher;
+    CRNode subscriber(runner);
 
     std::mutex                                cv_mtx;
     std::condition_variable                   cv;


### PR DESCRIPTION
Some operations of the node needs the existence of runner. Force the
user to construct the node with the runner so that users will be less
likely to miss the runner setting.