### PR TITLE
Adding `Stop` for JobRunner

### DIFF
--- a/src/sched/job_runner.h
+++ b/src/sched/job_runner.h
@@ -55,6 +55,8 @@ class JobRunner : public std::enable_shared_from_this<JobRunner> {
     /// @return true if any job was stolen
     bool Steal();
 
+    void Stop();
+
     void NotifyOneWorker();
 
     std::size_t ThreadNum() const;


### PR DESCRIPTION
During destruction phase, if we cannot guarantee that there are no more
incoming messages, we should stop the runner before destructing nodes
to avoid use-after-free.