### PR TITLE
Disable RTTI for LevelDB Comparator

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -38,23 +38,40 @@ cris_cc_library (
 )
 
 cris_cc_library (
-    name = "msg_recorder",
-    srcs = glob([
-            "src/msg_recorder/**/*.cc",
-            "src/msg_recorder/impl/**/*.h",
-    ]),
-    hdrs = glob([
-            "src/msg_recorder/**/*.h",
-        ], exclude = [
-            "src/msg_recorder/impl/**/*.h",
-    ]),
+    name = "msg_record_file",
+    srcs = ["src/msg_recorder/record_file.cc"],
+    hdrs = ["src/msg_recorder/record_file.h"],
     include_prefix = "cris/core",
     strip_include_prefix = "src",
+    copts = [
+        "-fno-rtti",
+    ],
     linkopts = [
         "-lleveldb",
     ],
     deps = [
+        ":utils",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+cris_cc_library (
+    name = "msg_recorder",
+    srcs = [
+        "src/msg_recorder/recorder.cc",
+        "src/msg_recorder/replayer.cc",
+        "src/msg_recorder/impl/utils.h",
+        "src/msg_recorder/impl/utils.cc",
+    ],
+    hdrs = [
+        "src/msg_recorder/recorder.h",
+        "src/msg_recorder/replayer.h",
+    ],
+    include_prefix = "cris/core",
+    strip_include_prefix = "src",
+    deps = [
         ":msg",
+        ":msg_record_file",
         "@fmt//:libfmt",
     ],
 )

--- a/src/msg_recorder/record_file.cc
+++ b/src/msg_recorder/record_file.cc
@@ -4,6 +4,8 @@
 #include "cris/core/utils/logging.h"
 #include "cris/core/utils/time.h"
 
+#include "leveldb/comparator.h"
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -12,8 +14,6 @@
 #include <string>
 #include <type_traits>
 #include <utility>
-
-#include "leveldb/comparator.h"
 
 namespace cris::core {
 
@@ -91,8 +91,8 @@ void RecordFileIterator::Next() {
 
 RecordFile::RecordFile(std::string file_path) : file_path_(std::move(file_path)) {
     static RecordFileKeyLdbComparator leveldb_cmp_;
-    leveldb::DB*     db;
-    leveldb::Options options;
+    leveldb::DB*                      db;
+    leveldb::Options                  options;
     options.create_if_missing = true;
     options.comparator        = &leveldb_cmp_;
     auto status               = leveldb::DB::Open(options, file_path_, &db);

--- a/src/msg_recorder/record_file.cc
+++ b/src/msg_recorder/record_file.cc
@@ -17,7 +17,7 @@
 
 namespace cris::core {
 
-class RecordFileKeyLdbComparator : public leveldb::Comparator {
+class RecordFileKeyLdbCmp : public leveldb::Comparator {
    public:
     int Compare(const leveldb::Slice& lhs, const leveldb::Slice& rhs) const override;
 
@@ -61,11 +61,11 @@ int RecordFileKey::compare(const RecordFileKey& lhs, const RecordFileKey& rhs) {
     }
 }
 
-int RecordFileKeyLdbComparator::Compare(const leveldb::Slice& lhs, const leveldb::Slice& rhs) const {
+int RecordFileKeyLdbCmp::Compare(const leveldb::Slice& lhs, const leveldb::Slice& rhs) const {
     return RecordFileKey::compare(RecordFileKey::FromSlice(lhs), RecordFileKey::FromSlice(rhs));
 }
 
-const char* RecordFileKeyLdbComparator::Name() const {
+const char* RecordFileKeyLdbCmp::Name() const {
     static const auto name = GetTypeName<std::remove_cvref_t<decltype(*this)>>();
     return name.c_str();
 }
@@ -90,9 +90,9 @@ void RecordFileIterator::Next() {
 }
 
 RecordFile::RecordFile(std::string file_path) : file_path_(std::move(file_path)) {
-    static RecordFileKeyLdbComparator leveldb_cmp_;
-    leveldb::DB*                      db;
-    leveldb::Options                  options;
+    static RecordFileKeyLdbCmp leveldb_cmp_;
+    leveldb::DB*               db;
+    leveldb::Options           options;
     options.create_if_missing = true;
     options.comparator        = &leveldb_cmp_;
     auto status               = leveldb::DB::Open(options, file_path_, &db);

--- a/src/msg_recorder/record_file.h
+++ b/src/msg_recorder/record_file.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "cris/core/msg/message.h"
 #include "cris/core/utils/time.h"
 
-#include "leveldb/comparator.h"
 #include "leveldb/db.h"
 
 #include <memory>
@@ -18,17 +16,6 @@ struct RecordFileKey {
     static RecordFileKey FromSlice(const leveldb::Slice& slice);
 
     static int compare(const RecordFileKey& lhs, const RecordFileKey& rhs);
-
-    class LevelDBComparator : public leveldb::Comparator {
-       public:
-        int Compare(const leveldb::Slice& lhs, const leveldb::Slice& rhs) const override;
-
-        const char* Name() const override;
-
-        // Ignore the following.
-        void FindShortestSeparator(std::string*, const leveldb::Slice&) const override {}
-        void FindShortSuccessor(std::string*) const override {}
-    };
 
     // Use timestamp as primary for easier db merging and cross-db comparison.
     cr_timestamp_nsec_t timestamp_{0};
@@ -85,13 +72,6 @@ class RecordFile {
    protected:
     std::string                      file_path_;
     std::unique_ptr<leveldb::DB>     db_;
-    RecordFileKey::LevelDBComparator leveldb_cmp_;
 };
-
-template<CRMessageType message_t>
-void MessageFromStr(message_t& msg, const std::string& serialized_msg);
-
-template<CRMessageType message_t>
-std::string MessageToStr(const message_t& msg);
 
 }  // namespace cris::core

--- a/src/msg_recorder/record_file.h
+++ b/src/msg_recorder/record_file.h
@@ -70,8 +70,8 @@ class RecordFile {
     bool Empty() const;
 
    protected:
-    std::string                      file_path_;
-    std::unique_ptr<leveldb::DB>     db_;
+    std::string                  file_path_;
+    std::unique_ptr<leveldb::DB> db_;
 };
 
 }  // namespace cris::core

--- a/src/msg_recorder/recorder.h
+++ b/src/msg_recorder/recorder.h
@@ -44,6 +44,9 @@ class MessageRecorder : public CRNamedNode<MessageRecorder> {
 };
 
 template<CRMessageType message_t>
+std::string MessageToStr(const message_t& msg);
+
+template<CRMessageType message_t>
 void MessageRecorder::RegisterChannel(const MessageRecorder::channel_subid_t subid, const std::string& alias) {
     auto* record_file = CreateFile(GetTypeName<message_t>(), subid, alias);
 

--- a/src/msg_recorder/replayer.h
+++ b/src/msg_recorder/replayer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cris/core/msg/message.h"
 #include "cris/core/msg/node.h"
 #include "cris/core/msg_recorder/record_file.h"
 
@@ -69,6 +70,9 @@ class MessageReplayer : public CRNamedNode<MessageReplayer> {
     std::vector<std::unique_ptr<RecordFile>> record_files_;
     RecordReaderPQueue                       record_readers_;
 };
+
+template<CRMessageType message_t>
+void MessageFromStr(message_t& msg, const std::string& serialized_msg);
 
 template<CRMessageType message_t>
 void MessageReplayer::RegisterChannel(const MessageReplayer::channel_subid_t subid) {


### PR DESCRIPTION
Since 1.23, LevelDB was built with RTTI disabled and no typeinfo
will be generated for the virtual base class leveldb::Comparator.
So we should build our Comparator without RTTI otherwise the linker
might complain about the missing symbols.