### PR TITLE
Add JobAliveToken for Stranded Jobs

### DIFF
--- a/src/sched/job_runner.h
+++ b/src/sched/job_runner.h
@@ -14,6 +14,9 @@ class JobRunnerWorker;
 // An object for serialized jobs. The jobs bound to the same strand object must run sequentially.
 class JobRunnerStrand;
 
+// An object for extending the lifecycle of one job in the strand.
+class JobAliveToken;
+
 class JobRunner : public std::enable_shared_from_this<JobRunner> {
    public:
     using Self = JobRunner;
@@ -48,6 +51,8 @@ class JobRunner : public std::enable_shared_from_this<JobRunner> {
     bool AddJob(job_t&& job) { return AddJob(std::move(job), DefaultSchedulerHint()); }
 
     bool AddJob(job_t&& job, std::shared_ptr<JobRunnerStrand> strand);
+
+    bool AddJob(std::function<void(std::shared_ptr<JobAliveToken>&&)>&& job, std::shared_ptr<JobRunnerStrand> strand);
 
     ///
     /// Randomly steal a job from the workers and run.


### PR DESCRIPTION
`JobRunnerStrand` serializes the jobs, but it is linear. It cannot
handle the "sausage-like" scheduling while a single job may depend
on multiple jobs. `JobAliveToken` solves it by extending the lifetime
of the stranded job while releasing the job worker threads. When the
token is alive, the current job will be considered as unfinished and the next
job in the strand will not be scheduled even if the current job has
exited.

For example, when the job A, B, C is serialized by `JobRunnerStrand`,
but B wants to spawning a few jobs and let them finish before running
C, then we pass the alive token of B to its spawned jobs:

```
runner.AddJob([&](std::unique_ptr<JobAliveToken>&& alive_token) {
    // Function body of B.
    // ...

    // Spawning helper jobs
    runner.AddJob([alive_token] {
        // Body of spawned helper job.
        // ...

        // While exit, sp alive_token is destructed. When the ref count
        // reduces to zero, the JobAliveToken instance will be
        // destructed. The job B will be considered as complete and the
        // job C will be scheduled after that.
    });

    // B exits, but since JobAliveToken is still alive, C will not be
    // scheduled until all spawned job finished.
}, strand);
```