### PR TITLE
Fix Ambiguity when Subscribing Messages

### DIFF
--- a/src/msg/node.h
+++ b/src/msg/node.h
@@ -24,7 +24,8 @@ concept CRSingleMessageCallbackType = std::is_base_of_v<CRMessageBase, message_t
 
 template<class callback_t, class message_t = CRMessageBase>
 concept CRMessageWithAliveTokenCallbackType =
-    std::is_base_of_v<CRMessageBase, message_t> && std::is_void_v<decltype(std::declval<callback_t>()(
+    !CRSingleMessageCallbackType<callback_t, message_t> && std::is_base_of_v<CRMessageBase, message_t> &&
+    std::is_void_v<decltype(std::declval<callback_t>()(
         std::declval<const std::shared_ptr<message_t>&>(),
         std::declval<JobAliveTokenPtr>()))>;
 


### PR DESCRIPTION
`std::bind` result type may allow extra parameters, so there might be
false-positive on the callback type check, which will result in
ambiguity.