### PR TITLE
Headers must be in "hdrs", or clang-tidy may treat `.h` as C file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -50,6 +50,18 @@ cris_cc_library (
 )
 
 cris_cc_library (
+    name = "internal_msg_recorder_utils",
+    srcs = glob(["src/msg_recorder/impl/**/*.cc"]),
+    hdrs = glob(["src/msg_recorder/impl/**/*.h"]),
+    include_prefix = "cris/core",
+    strip_include_prefix = "src",
+    deps = [
+        ":msg",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+cris_cc_library (
     name = "internal_msg_record_file",
     srcs = ["src/msg_recorder/record_file.cc"],
     hdrs = ["src/msg_recorder/record_file.h"],
@@ -73,8 +85,6 @@ cris_cc_library (
     srcs = [
         "src/msg_recorder/recorder.cc",
         "src/msg_recorder/replayer.cc",
-        "src/msg_recorder/impl/utils.h",
-        "src/msg_recorder/impl/utils.cc",
     ],
     hdrs = [
         "src/msg_recorder/recorder.h",
@@ -85,6 +95,7 @@ cris_cc_library (
     deps = [
         ":msg",
         ":internal_msg_record_file",
+        ":internal_msg_recorder_utils",
         "@fmt//:libfmt",
     ],
 )

--- a/src/msg_recorder/impl/utils.cc
+++ b/src/msg_recorder/impl/utils.cc
@@ -1,4 +1,4 @@
-#include "utils.h"
+#include "cris/core/msg_recorder/impl/utils.h"
 
 #include <algorithm>
 #include <cctype>


### PR DESCRIPTION
Reference (but not dependencies)
- https://github.com/cyfitech/cris-core/pull/108