### PR TITLE
Install llvm-13 toolchains for all 3 docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,6 +108,27 @@ RUN set -e; \
         sudo rm -rf /var/lib/apt/lists/*; \
         ;; \
     esac; \
+    case "$DISTRO_ID-$DISTRO_VERSION_ID/$CRIS_IMG_ARCH" in \
+    'ubuntu-20.04/amd64') \
+        echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -cs)-proposed restricted main multiverse universe" \
+        | sudo tee /etc/apt/sources.list.d/ubuntu-$(lsb_release -cs)-proposed.list \
+        > /dev/null; \
+        ;; \
+    'ubuntu-20.04/'*) \
+        echo "deb http://ports.ubuntu.com/ubuntu-ports $(lsb_release -cs)-proposed restricted main multiverse universe" \
+        | sudo tee /etc/apt/sources.list.d/ubuntu-$(lsb_release -cs)-proposed.list \
+        > /dev/null; \
+        ;; \
+    esac; \
+    if [ _"$DISTRO_ID" == '_ubuntu' ]; then \
+        printf '%s\n' \
+            '# Configure apt to allow selective installs of packages from proposed' \
+            'Package: *' \
+            "Pin: release a=$(lsb_release -cs)-proposed" \
+            'Pin-Priority: 400' \
+        | sudo tee /etc/apt/preferences.d/proposed-updates \
+        > /dev/null; \
+    fi; \
     truncate -s0 ~/.bash_history;
 
 FROM bootstrap as dev
@@ -195,6 +216,8 @@ RUN set -e; \
                 libtool \
                 llvm-11{,-tools} {clang{,-{format,tidy,tools}},lld}-11 \
                 $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[02]\.04$' >/dev/null || echo llvm-12{,-tools} {clang{,-{format,tidy,tools}},lld}-12) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[024]\.04$' >/dev/null || echo llvm-13{,-tools} {clang{,-{format,tidy,tools}},lld}-13) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^debian\-1[12]$' >/dev/null || echo llvm-13{,-tools} {clang{,-{format,tidy,tools}},lld}-13) \
                 $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[24]\.04$' >/dev/null || echo llvm-14{,-tools} {clang{,-{format,tidy,tools}},lld}-14) \
                 locales \
                 locate \


### PR DESCRIPTION
- For Ubuntu 22.04 and Debian 11, llvm-13 is from the system distro.
- For Ubuntu 20.04, we are using the "-proposed" pre-released updates, but we have disabled upgrading from this source.