### PR TITLE
Use envvar "CLANG_TIDY" instead of "CLANG_TIDY_BIN"

### DIFF
--- a/bazel/repo/clang_tidy_wrapper.sh.tpl
+++ b/bazel/repo/clang_tidy_wrapper.sh.tpl
@@ -5,4 +5,4 @@ set -e
 # HACK(chenhao94): Bazel will redefine built-in macros (e.g., "__DATE__") for
 # deterministic builds, and it triggers the Clang Tidy check.
 # See https://github.com/erenon/bazel_clang_tidy/issues/29
-%{CLANG_TIDY_BIN} --checks=-clang-diagnostic-builtin-macro-redefined "$@"
+%{CLANG_TIDY} --checks=-clang-diagnostic-builtin-macro-redefined "$@"

--- a/bazel/repo/toolchain.bzl
+++ b/bazel/repo/toolchain.bzl
@@ -1,5 +1,5 @@
 def cc_autoconf_toolchain_impl(repo_ctx):
-    clang_tidy_bin_raw = repo_ctx.os.environ.get("CLANG_TIDY_BIN", "clang-tidy")
+    clang_tidy_bin_raw = repo_ctx.os.environ.get("CLANG_TIDY", "clang-tidy")
     clang_tidy_bin_full_path = repo_ctx.which(clang_tidy_bin_raw)
     repo_ctx.file(
         "BUILD",
@@ -14,13 +14,13 @@ filegroup(
         "clang_tidy_wrapper.sh",
         Label("@cris-core//bazel/repo:clang_tidy_wrapper.sh.tpl"),
         {
-            "%{CLANG_TIDY_BIN}": str(clang_tidy_bin_full_path),
+            "%{CLANG_TIDY}": str(clang_tidy_bin_full_path),
         },
     )
 
 cc_autoconf_toolchain = repository_rule(
     environ = [
-        "CLANG_TIDY_BIN",
+        "CLANG_TIDY",
     ],
     implementation = cc_autoconf_toolchain_impl,
     configure = True,


### PR DESCRIPTION
We are using "CLANG_FORMAT" for the clang-format binary, so "CLANG_TIDY" seems to be more consistent with the formatter bin.