### PR TITLE
Several Hacks on the Clang Tidy Wrapper Script

### DIFF
--- a/bazel/repo/clang_tidy_wrapper.sh.tpl
+++ b/bazel/repo/clang_tidy_wrapper.sh.tpl
@@ -2,7 +2,23 @@
 
 set -e
 
+# HACK(chenhao94): Skip all the "textual" sources.
+if printf "%s\n" "$@" | grep "\.txt\.h\(pp\)\?$" > /dev/null; then
+    exit 0;
+fi
+
 # HACK(chenhao94): Bazel will redefine built-in macros (e.g., "__DATE__") for
 # deterministic builds, and it triggers the Clang Tidy check.
 # See https://github.com/erenon/bazel_clang_tidy/issues/29
-%{CLANG_TIDY} --checks=-clang-diagnostic-builtin-macro-redefined "$@"
+# HACK(chenhao94): Skip all the generated protobuf headers.
+%{CLANG_TIDY} \
+    --checks=-clang-diagnostic-builtin-macro-redefined \
+    --line-filter='[
+            {"name":".pb.h","lines":[[9999999,9999999]]},
+            {"name":".h"},
+            {"name":".hpp"},
+            {"name":".c"},
+            {"name":".cc"},
+            {"name":".cpp"}
+        ]' \
+    "$@"


### PR DESCRIPTION
- Skip the checks for the "textual" sources. They are not real C++ source code, but only added as "sources" for other compilation usage.
- Skip the checks for the auto-generated Protobuf headers. They are under the "cris/..." path but the linter should not touch them.