### PR TITLE
Add Generic Job Queue Base Class

### DIFF
--- a/src/sched/job_lockfree_queue.cc
+++ b/src/sched/job_lockfree_queue.cc
@@ -1,0 +1,37 @@
+#include "cris/core/sched/job_lockfree_queue.h"
+
+#include <functional>
+#include <utility>
+
+namespace cris::core {
+
+JobLockFreeQueue::JobLockFreeQueue(std::size_t init_capacity) : jobs_(init_capacity) {
+}
+
+JobLockFreeQueue::~JobLockFreeQueue() {
+    JobLockFreeQueue::ConsumeAll([](auto&&) {});
+}
+
+void JobLockFreeQueue::Push(job_t job) {
+    jobs_.push(new job_t(std::move(job)));
+}
+
+bool JobLockFreeQueue::ConsumeOne(const std::function<void(job_t&&)>& functor) {
+    return jobs_.consume_one([&functor](job_t* const job_ptr) {
+        functor(std::move(*job_ptr));
+        delete job_ptr;
+    });
+}
+
+bool JobLockFreeQueue::ConsumeAll(const std::function<void(job_t&&)>& functor) {
+    return jobs_.consume_all([&functor](job_t* const job_ptr) {
+        functor(std::move(*job_ptr));
+        delete job_ptr;
+    });
+}
+
+bool JobLockFreeQueue::Empty() {
+    return jobs_.empty();
+}
+
+}  // namespace cris::core

--- a/src/sched/job_lockfree_queue.h
+++ b/src/sched/job_lockfree_queue.h
@@ -14,9 +14,9 @@
 
 namespace cris::core {
 
-class JobLockFreeQueue : public JobQueueBase {
+class JobLockFreeQueue : public JobQueue {
    public:
-    using job_t = JobQueueBase::job_t;
+    using job_t = JobQueue::job_t;
 
     explicit JobLockFreeQueue(std::size_t init_capacity = 8);
     ~JobLockFreeQueue() override;

--- a/src/sched/job_lockfree_queue.h
+++ b/src/sched/job_lockfree_queue.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "cris/core/sched/job_queue.h"
+
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wambiguous-reversed-operator"
+#endif
+
+#include <boost/lockfree/queue.hpp>
+
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+namespace cris::core {
+
+class JobLockFreeQueue : public JobQueueBase {
+   public:
+    using job_t = JobQueueBase::job_t;
+
+    explicit JobLockFreeQueue(std::size_t init_capacity = 8);
+    ~JobLockFreeQueue() override;
+
+    void Push(job_t job) override;
+
+    bool ConsumeOne(const std::function<void(job_t&&)>& functor) override;
+
+    bool ConsumeAll(const std::function<void(job_t&&)>& functor) override;
+
+    bool Empty() override;
+
+   private:
+    boost::lockfree::queue<job_t*> jobs_;
+};
+
+}  // namespace cris::core

--- a/src/sched/job_queue.cc
+++ b/src/sched/job_queue.cc
@@ -4,15 +4,15 @@
 
 namespace cris::core {
 
-using job_t = JobQueueBase::job_t;
+using job_t = JobQueue::job_t;
 
-void JobQueueBase::PushBatch(std::vector<job_t> jobs) {
+void JobQueue::PushBatch(std::vector<job_t> jobs) {
     for (auto& job : jobs) {
         Push(std::move(job));
     }
 }
 
-bool JobQueueBase::ConsumeAll(const std::function<void(job_t&&)>& functor) {
+bool JobQueue::ConsumeAll(const std::function<void(job_t&&)>& functor) {
     bool consumed = false;
     while (ConsumeOne(functor)) {
         consumed = true;

--- a/src/sched/job_queue.cc
+++ b/src/sched/job_queue.cc
@@ -1,0 +1,23 @@
+#include "cris/core/sched/job_queue.h"
+
+#include <utility>
+
+namespace cris::core {
+
+using job_t = JobQueueBase::job_t;
+
+void JobQueueBase::PushBatch(std::vector<job_t> jobs) {
+    for (auto& job : jobs) {
+        Push(std::move(job));
+    }
+}
+
+bool JobQueueBase::ConsumeAll(const std::function<void(job_t&&)>& functor) {
+    bool consumed = false;
+    while (ConsumeOne(functor)) {
+        consumed = true;
+    }
+    return consumed;
+}
+
+}  // namespace cris::core

--- a/src/sched/job_queue.h
+++ b/src/sched/job_queue.h
@@ -7,11 +7,11 @@
 
 namespace cris::core {
 
-class JobQueueBase {
+class JobQueue {
    public:
     using job_t = JobRunner::job_t;
 
-    virtual ~JobQueueBase() = default;
+    virtual ~JobQueue() = default;
 
     virtual void Push(job_t job) = 0;
 

--- a/src/sched/job_queue.h
+++ b/src/sched/job_queue.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "cris/core/sched/job_runner.h"
+
+#include <functional>
+#include <vector>
+
+namespace cris::core {
+
+class JobQueueBase {
+   public:
+    using job_t = JobRunner::job_t;
+
+    virtual ~JobQueueBase() = default;
+
+    virtual void Push(job_t job) = 0;
+
+    virtual void PushBatch(std::vector<job_t> jobs);
+
+    virtual bool ConsumeOne(const std::function<void(job_t&&)>& functor) = 0;
+
+    virtual bool ConsumeAll(const std::function<void(job_t&&)>& functor);
+
+    virtual bool Empty() = 0;
+};
+
+}  // namespace cris::core


### PR DESCRIPTION
JobRunner can be agnostic of the underlying queue
so that we can easily switch different job queue implementation and choose the best one. So, we need a generic job queue abstraction.