### PR TITLE
Stacktrace test

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -179,4 +179,3 @@ cris_cc_test (
         "@cris-core//tests:cris_gtest_main",
     ],
 )
-

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -170,3 +170,13 @@ cris_cc_test (
     ],
 )
 
+cris_cc_test (
+    name = "stacktrace_test",
+    srcs = ["stacktrace_test.cc"],
+    tags = ["manual"],
+    deps = [
+        "//:signal",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+

--- a/tests/stacktrace_test.cc
+++ b/tests/stacktrace_test.cc
@@ -1,4 +1,5 @@
 #include "cris/core/signal/cr_signal.h"
+#include "cris/core/utils/logging.h"
 
 #include "gtest/gtest.h"
 
@@ -7,10 +8,12 @@
 namespace cris::core {
 
 __attribute__((noinline)) static void CrashTestInnerFunc() {
+    LOG(INFO) << __func__ << ": Generate side-effect to prevent this function from being optimized away.";
     std::abort();
 }
 
 __attribute__((noinline)) static void CrashTestFunc() {
+    LOG(INFO) << __func__ << ": Generate side-effect to prevent this function from being optimized away.";
     CrashTestInnerFunc();
 }
 

--- a/tests/stacktrace_test.cc
+++ b/tests/stacktrace_test.cc
@@ -1,0 +1,24 @@
+#include "cris/core/signal/cr_signal.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+
+namespace cris::core {
+
+__attribute__((noinline)) static void CrashTestInnerFunc() {
+    std::abort();
+}
+
+__attribute__((noinline)) static void CrashTestFunc() {
+    CrashTestInnerFunc();
+}
+
+TEST(StacktraceTest, Basics) {
+    InstallSignalHandler();
+
+    // Stacktrace should at least include the function names of 2 stack frames.
+    EXPECT_DEATH(CrashTestFunc(), "\\bCrashTestInnerFunc().*\n.*\\bCrashTestFunc()");
+}
+
+}  // namespace cris::core


### PR DESCRIPTION
This test checks if stacktrace was printed correctly when handling deadly signals. Mark it as "manual" for now because it fails on gcc.

Related issue:
- https://github.com/cyfitech/cris-core/issues/95