### PR TITLE
Fix GCC Stacktrace by using Libbacktrace

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -130,9 +130,9 @@ cris_cc_library (
 )
 
 selects.config_setting_group(
-    name = "osx_use_clang",
+    name = "macos_use_clang",
     match_all = [
-        "@platforms//os:osx",
+        "@platforms//os:macos",
         "use_clang",
     ]
 )
@@ -165,13 +165,13 @@ cris_cc_library (
     include_prefix = "cris/core",
     strip_include_prefix = "src",
     copts = select({
-        "osx_use_clang" :       ["-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED"],
+        "macos_use_clang" :     ["-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED"],
         "linux_use_gcc" :       ["-DBOOST_STACKTRACE_USE_BACKTRACE"],
         "linux_use_clang":      ["-DBOOST_STACKTRACE_USE_ADDR2LINE"],
         "//conditions:default": ["-DBOOST_STACKTRACE_USE_BACKTRACE"],  # Assume GCC.
     }),
     linkopts = select({
-        "osx_use_clang" :       [],
+        "macos_use_clang" :     [],
         "linux_use_gcc" :       ["-ldl", "-lbacktrace"],
         "linux_use_clang":      ["-ldl"],
         "//conditions:default": ["-ldl", "-lbacktrace"],  # Assume GCC.

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -173,7 +173,6 @@ cris_cc_test (
 cris_cc_test (
     name = "stacktrace_test",
     srcs = ["stacktrace_test.cc"],
-    tags = ["manual"],
     deps = [
         "//:signal",
         "@cris-core//tests:cris_gtest_main",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -173,6 +173,7 @@ cris_cc_test (
 cris_cc_test (
     name = "stacktrace_test",
     srcs = ["stacktrace_test.cc"],
+    tags = ["manual"],
     deps = [
         "//:signal",
         "@cris-core//tests:cris_gtest_main",

--- a/tests/stacktrace_test.cc
+++ b/tests/stacktrace_test.cc
@@ -21,7 +21,7 @@ TEST(StacktraceTest, Basics) {
     InstallSignalHandler();
 
     // Stacktrace should at least include the function names of 2 stack frames.
-    EXPECT_DEATH(CrashTestFunc(), "cris::core::CrashTestInnerFunc().*\n.*cris::core::CrashstFunc()");
+    EXPECT_DEATH(CrashTestFunc(), "cris::core::CrashTestInnerFunc().*\n.*cris::core::CrashTestFunc()");
 }
 
 }  // namespace cris::core

--- a/tests/stacktrace_test.cc
+++ b/tests/stacktrace_test.cc
@@ -21,6 +21,8 @@ TEST(StacktraceTest, Basics) {
     InstallSignalHandler();
 
     // Stacktrace should at least include the function names of 2 stack frames.
+    // EXPECT_DEATH contains `goto`.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto,-warnings-as-errors)
     EXPECT_DEATH(CrashTestFunc(), "cris::core::CrashTestInnerFunc().*\n.*cris::core::CrashTestFunc()");
 }
 

--- a/tests/stacktrace_test.cc
+++ b/tests/stacktrace_test.cc
@@ -21,7 +21,7 @@ TEST(StacktraceTest, Basics) {
     InstallSignalHandler();
 
     // Stacktrace should at least include the function names of 2 stack frames.
-    EXPECT_DEATH(CrashTestFunc(), "\\bCrashTestInnerFunc().*\n.*\\bCrashTestFunc()");
+    EXPECT_DEATH(CrashTestFunc(), "cris::core::CrashTestInnerFunc().*\n.*cris::core::CrashstFunc()");
 }
 
 }  // namespace cris::core


### PR DESCRIPTION
Related Issue:
- https://github.com/cyfitech/cris-core/issues/95

This is not a complete fix of the issue above, since neither `addr2line` nor libgcc works for Apple Clang.