### PR TITLE
Print the stacktrace line-by-line in case it is too long

### DIFF
--- a/src/signal/cr_signal.cc
+++ b/src/signal/cr_signal.cc
@@ -71,8 +71,11 @@ static void DumpStacktrace() {
     RAW_LOG(ERROR, "*******************   STACKTRACE   *******************");
     RAW_LOG(ERROR, "******************************************************");
     std::stringstream trace;
+    trace << '\n';
     trace << boost::stacktrace::stacktrace();
-    RAW_LOG(ERROR, "\n%s", trace.str().c_str());
+    for (std::string trace_line; std::getline(trace, trace_line);) {
+        RAW_LOG(ERROR, "%s", trace_line.c_str());
+    }
 }
 
 static std::atomic<pthread_t*> current_thread_in_handler{nullptr};

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -173,7 +173,6 @@ cris_cc_test (
 cris_cc_test (
     name = "stacktrace_test",
     srcs = ["stacktrace_test.cc"],
-    tags = ["manual"],
     deps = [
         "//:signal",
         "@cris-core//tests:cris_gtest_main",


### PR DESCRIPTION
Fixes the bugs like this:

```
[  DEATH   ] E00000000 00:00:00.000000    15 cr_signal.cc:70] RAW: ******************************************************
[  DEATH   ] E00000000 00:00:00.000000    15 cr_signal.cc:71] RAW: *******************   STACKTRACE   *******************
[  DEATH   ] E00000000 00:00:00.000000    15 cr_signal.cc:72] RAW: ******************************************************
[  DEATH   ] E00000000 00:00:00.000000    15 cr_signal.cc:75] RAW: RAW_LOG ERROR: The Message was too long!
```

Fixes:

- https://github.com/cyfitech/cris-core/issues/95