### PR TITLE
Add utilities for rolling

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,6 +25,7 @@ cris_cc_library (
     strip_include_prefix = "src",
     deps = [
         "@com_github_google_glog//:glog",
+        "@fmt//:libfmt",
     ],
 )
 

--- a/src/utils/time.cc
+++ b/src/utils/time.cc
@@ -11,6 +11,11 @@
 #include <x86intrin.h>
 #endif
 
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <fmt/core.h>
+
 #include <chrono>
 #include <cstdint>
 #include <thread>
@@ -71,6 +76,40 @@ cr_timestamp_nsec_t GetUnixTimestampNsec() {
     using std::chrono::nanoseconds;
     using std::chrono::system_clock;
     return static_cast<cr_timestamp_nsec_t>(duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count());
+}
+
+std::string GetCurrentUtcDate() {
+    using namespace boost::gregorian;
+
+    return to_iso_string(day_clock::universal_day());
+}
+
+std::string GetCurrentUtcHour() {
+    using namespace boost::gregorian;
+    using namespace boost::posix_time;
+
+    const auto utc_time = second_clock::universal_time();
+    return fmt::format("{}{:02}", to_iso_string(utc_time.date()), utc_time.time_of_day().hours());
+}
+
+bool SameUtcDay(const std::chrono::system_clock::time_point x, const std::chrono::system_clock::time_point y) noexcept {
+    using std::chrono::days;
+    using std::chrono::duration_cast;
+
+    const auto days_x = duration_cast<days>(x.time_since_epoch()).count();
+    const auto days_y = duration_cast<days>(y.time_since_epoch()).count();
+    return days_x == days_y;
+}
+
+bool SameUtcHour(
+    const std::chrono::system_clock::time_point x,
+    const std::chrono::system_clock::time_point y) noexcept {
+    using std::chrono::duration_cast;
+    using std::chrono::hours;
+
+    const auto hours_x = duration_cast<hours>(x.time_since_epoch()).count();
+    const auto hours_y = duration_cast<hours>(y.time_since_epoch()).count();
+    return hours_x == hours_y;
 }
 
 }  // namespace cris::core

--- a/src/utils/time.h
+++ b/src/utils/time.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
+#include <string>
 
 namespace cris::core {
 
@@ -15,5 +17,15 @@ cr_timestamp_nsec_t GetSystemTimestampNsec();
 
 // Real-world timestamp.
 cr_timestamp_nsec_t GetUnixTimestampNsec();
+
+// e.g., 20230224
+std::string GetCurrentUtcDate();
+
+// e.g., 2023022407
+std::string GetCurrentUtcHour();
+
+bool SameUtcDay(const std::chrono::system_clock::time_point x, const std::chrono::system_clock::time_point y) noexcept;
+
+bool SameUtcHour(const std::chrono::system_clock::time_point x, const std::chrono::system_clock::time_point y) noexcept;
 
 }  // namespace cris::core

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -29,6 +29,15 @@ cris_cc_test (
 )
 
 cris_cc_test (
+    name = "time_test",
+    srcs = ["time_test.cc"],
+    deps = [
+        "//:utils",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+
+cris_cc_test (
     name = "message_test",
     srcs = ["message_test.cc"],
     deps = [

--- a/tests/time_test.cc
+++ b/tests/time_test.cc
@@ -1,0 +1,38 @@
+#include "cris/core/utils/time.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+namespace cris::core {
+
+using namespace std::chrono;
+using TimePoint = system_clock::time_point;
+
+TEST(TimeTest, IsNotSameDay) {
+    constexpr TimePoint start = TimePoint{} + hours{1};
+    constexpr TimePoint end   = TimePoint{} + days{1};
+    EXPECT_FALSE(SameUtcDay(start, end));
+}
+
+TEST(TimeTest, IsSameDay) {
+    constexpr auto less_than_one_day = seconds{days::period::num - 1};
+    constexpr auto start             = TimePoint{};
+    constexpr auto end               = TimePoint{less_than_one_day};
+    EXPECT_TRUE(SameUtcDay(start, end));
+}
+
+TEST(TimeTest, IsNotSameHour) {
+    constexpr auto start = TimePoint{} + minutes{10};
+    constexpr auto end   = start + hours{1};
+    EXPECT_FALSE(SameUtcHour(start, end));
+}
+
+TEST(TimeTest, IsSameHour) {
+    constexpr auto less_than_one_hour = seconds{hours::period::num - 1};
+    constexpr auto start              = TimePoint{};
+    constexpr auto end                = TimePoint{less_than_one_hour};
+    EXPECT_TRUE(SameUtcHour(start, end));
+}
+
+}  // namespace cris::core


### PR DESCRIPTION
实现功能
- 获取当前UTC日期与小时时间的功能
- 判定两个时间戳是否位于UTC时间的同一天或同一小时

相关issues
- https://github.com/cyfitech/cris-core/issues/170
- https://github.com/cyfitech/cris-base/issues/146