### PR TITLE
Replay does not depend on dir hierarchy when finding record dir

### DIFF
--- a/src/msg_recorder/impl/utils.cc
+++ b/src/msg_recorder/impl/utils.cc
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <cctype>
-#include <set>
-#include <string>
+
+namespace fs = std::filesystem;
 
 namespace cris::core::impl {
 
@@ -14,6 +14,24 @@ std::string GetMessageRecordFileName(const std::string& message_type, const CRMe
     };
     std::replace_if(message_record_filename.begin(), message_record_filename.end(), message_type_replace_pred, '_');
     return message_record_filename + "_subid_" + std::to_string(subid) + ".ldb.d";
+}
+
+std::vector<fs::path> FindMatchedSubdirs(const fs::path& top_dir, const std::string_view dir_name) {
+    std::vector<fs::path> matches;
+
+    if (!fs::is_directory(top_dir)) {
+        return matches;
+    }
+
+    for (const auto& entry : fs::recursive_directory_iterator{top_dir}) {
+        if (fs::is_directory(entry) && entry.path().filename().native() == dir_name) {
+            matches.push_back(entry.path());
+        }
+    }
+
+    std::sort(std::begin(matches), std::end(matches));
+
+    return matches;
 }
 
 }  // namespace cris::core::impl

--- a/src/msg_recorder/impl/utils.h
+++ b/src/msg_recorder/impl/utils.h
@@ -2,10 +2,17 @@
 
 #include "cris/core/msg/message.h"
 
+#include <filesystem>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace cris::core::impl {
 
 std::string GetMessageRecordFileName(const std::string& message_type, const CRMessageBase::channel_subid_t subid);
+
+std::vector<std::filesystem::path> FindMatchedSubdirs(
+    const std::filesystem::path& top_dir,
+    const std::string_view       dir_name);
 
 }  // namespace cris::core::impl


### PR DESCRIPTION
为record rolling做准备工作，为了方便rolling，重新设计了目录层次，这会break replay

这个PR让replay不依赖record file目录层次，使用目录名match的方式查找对应的leveldb record file，因而可以兼容新的record file目录层次

- https://github.com/cyfitech/cris-core/pull/186#issue-1618314639


但replay仍不支持rolled record files (TODO)