### PR TITLE
Fix MessageRecorder rolling settings check

### DIFF
--- a/src/msg_recorder/recorder.cc
+++ b/src/msg_recorder/recorder.cc
@@ -11,11 +11,11 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
-#include <exception>
 #include <filesystem>
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -33,7 +33,7 @@ MessageRecorder::MessageRecorder(
     , full_record_dir_path_generator_(std::move(dir_path_generator))
     , record_strand_(MakeStrand())
     , snapshot_thread_(std::thread([this] { SnapshotWorker(); })) {
-    CHECK(CheckRollingSettings()) << "Dir path generator MUST be valid when rolling enabled!";
+    CHECK(CheckRollingSettings()) << ": Dir path generator must be callable when rolling enabled.";
 
     if (!full_record_dir_path_generator_) {  // Rolling is not enabled
         full_record_dir_path_generator_ = [this] {
@@ -42,8 +42,8 @@ MessageRecorder::MessageRecorder(
     }
 }
 
-bool MessageRecorder::CheckRollingSettings() const noexcept {
-    return recorder_config_.rolling_ == RecorderConfig::Rolling::kNone || !full_record_dir_path_generator_;
+bool MessageRecorder::CheckRollingSettings() const {
+    return recorder_config_.rolling_ == RecorderConfig::Rolling::kNone || full_record_dir_path_generator_;
 }
 
 void MessageRecorder::SetSnapshotJobPreStartCallback(
@@ -231,7 +231,7 @@ std::string MessageRecorder::SnapshotDirNameGenerator() {
         now);
 }
 
-const std::filesystem::path& MessageRecorder::GetRecordDir() const noexcept {
+const std::filesystem::path& MessageRecorder::GetRecordDir() const {
     return recorder_config_.record_dir_;
 }
 

--- a/src/msg_recorder/recorder.h
+++ b/src/msg_recorder/recorder.h
@@ -55,7 +55,7 @@ class MessageRecorder : public CRNamedNode<MessageRecorder> {
         const std::filesystem::path&                        snapshot_dir,
         const std::optional<RecorderConfig::IntervalConfig> interval_config = std::nullopt);
 
-    const std::filesystem::path& GetRecordDir() const noexcept;
+    const std::filesystem::path& GetRecordDir() const;
 
     // Mapping from interval names to snapshot lists. Snapshots are ordered from old to new in the lists.
     std::map<std::string, std::vector<std::filesystem::path>> GetSnapshotPaths();
@@ -71,7 +71,7 @@ class MessageRecorder : public CRNamedNode<MessageRecorder> {
 
     RecordFile* CreateFile(const std::string& message_type, const channel_subid_t subid, const std::string& alias);
 
-    bool CheckRollingSettings() const noexcept;
+    bool CheckRollingSettings() const;
 
     bool GenerateSnapshotImpl(const std::filesystem::path& snapshot_dir);
     void MaintainMaxNumOfSnapshots(const RecorderConfig::IntervalConfig& interval_config);

--- a/tests/msg_recorder_test.cc
+++ b/tests/msg_recorder_test.cc
@@ -234,6 +234,22 @@ TEST_F(RecorderTest, RecorderTest) {
     TestReplayCanceled();
 }
 
+TEST(MessageRecorder, CheckRollingSettings_NoRollingOK) {
+    RecorderConfig recorder_config;
+    recorder_config.record_dir_ = std::filesystem::temp_directory_path();
+    const MessageRecorder recorder{std::move(recorder_config), nullptr};
+    EXPECT_EQ(std::filesystem::temp_directory_path(), recorder.GetRecordDir());
+}
+
+TEST(MessageRecorder, CheckRollingSettings_InvalidRollingSetting) {
+    RecorderConfig recorder_config;
+    recorder_config.rolling_ = RecorderConfig::Rolling::kDay;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto,-warnings-as-errors)
+    EXPECT_DEATH(
+        MessageRecorder(std::move(recorder_config), nullptr),
+        "Dir path generator must be callable when rolling enabled");
+}
+
 TEST(RecorderUtilsTest, FindMatchedSubdirsOK) {
     namespace fs = std::filesystem;
     constexpr std::array dirs{"a/b/c", "a/d/c", "e", "f"};


### PR DESCRIPTION
测试时发现的bug：
当配置了rolling，且dir path generator有效，CHECK失败

**预期**
当配置了rolling，且dir path generator有效，CHECK成功

check条件写错了，应该是：当配置了rolling， 要求dir path generator有效

这个PR fix了这个bug，并且添加了相应的UT