### PR TITLE
We only need the rules_cc code, but no need to use its toolchain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,11 +10,6 @@ cris_core_deps()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-# TODO: Enable when ready.
-# load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
-# rules_cc_dependencies()
-# rules_cc_toolchains()
-
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 rules_foreign_cc_dependencies(register_default_tools=False, register_built_tools=False)
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -233,8 +233,7 @@ def cris_deps_bazel_clang_tidy(prefix = "."):
 
 def cris_core_deps(prefix = "."):
     cris_deps_bazel_skylib(prefix)
-    # TODO: Enable when ready.
-    # cris_deps_rules_cc(prefix)
+    cris_deps_rules_cc(prefix)
     cris_deps_rules_foreign_cc(prefix)
     cris_deps_rules_java(prefix)
     cris_deps_rules_pkg(prefix)


### PR DESCRIPTION
Test: `bazel clean --expunge` and clear the bazel download cache, and rebuild without the network connection.

Related Issue:
- https://github.com/cyfitech/cris-base/issues/97