### PR TITLE
Fix the Format Script Grep Issue

### DIFF
--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -51,6 +51,7 @@ done
 | tr '\n' '\0'                                                                                          \
 | $(which parallel >/dev/null 2>&1 && echo "parallel -j$(nproc) -m" || echo 'xargs -r'   ) -0           \
     grep -HI "$(printf '\r$')"                                                                          \
+| grep "$(printf ':.*\r$')"                                                                             \
 | cut -d: -f1                                                                                           \
 | grep -v $(set -e;                                                                                     \
     which git >/dev/null                                                                                \


### PR DESCRIPTION
On Ubuntu 20.04 (grep version 3.4), grep sometimes ignores the "-I" option and still printing "Binary file matches" message. So we need to filter those lines out.