### PR TITLE
Do not update rolling helper if failed to roll

### DIFF
--- a/src/msg_recorder/record_file.cc
+++ b/src/msg_recorder/record_file.cc
@@ -236,11 +236,13 @@ void RecordFile::Write(RecordFileKey key, std::string serialized_value) {
         .time       = std::chrono::system_clock::now(),
         .value_size = serialized_value.size()};
 
+    bool roll_failed = false;
     if (rolling_helper_ && rolling_helper_->NeedToRoll(metadata) && !Roll()) {
+        roll_failed = true;
         LOG(ERROR) << __func__ << ": Failed to roll records, fallback to current db.";
     }
 
-    if (Write(key_str, serialized_value) && rolling_helper_) {
+    if (Write(key_str, serialized_value) && rolling_helper_ && !roll_failed) {
         rolling_helper_->Update(metadata);
     }
 }


### PR DESCRIPTION
测试时发现的问题：check是否应该roll的时候已经判定是新的一天，应该roll，但是生成目录使用的时间仍是前一天，导致roll失败（因为前一天的目录已经存在并且正在使用）

```log
E20230323 00:00:00.002579 1233327 record_file.cc:203] OpenDB: Failed to create record file "xyz.72599808.ldb.d/LOCK: already held by process
```
### 原因分析
这是一个corner case，可能是ntp时间调整导致：
>如果时间刚好到0点，check发现需要rolling，但是在执行roll之前，时钟因为NTP倒退到前一天23:59:59.999...，此时获取时间就是前一天，以此为目录名，那么会打开前一天的db（但此时该db已经是open状态，LevelDB不允许一个已经打开的db instance被再次打开，直接报错）

目前的实现为，无论roll是否成功都会update rolling_helper metadata(time, size)，就跳过了一次rolling

但其实应该继续尝试roll，因为倒退的时间仍会继续往前走，很快就会到新的一天，所以可能下一次Write就能成功roll


本PR的作用为
- 如果roll失败，则不更新rolling_helper的metadata，因此下一次Write数据仍尝试roll