### PR TITLE
Use timestamp(UTC) + pid as subdir for rolling

### DIFF
--- a/src/msg_recorder/recorder.cc
+++ b/src/msg_recorder/recorder.cc
@@ -270,24 +270,24 @@ std::unique_ptr<RollingHelper> CreateRollingHelper(
         case RecorderConfig::Rolling::kHour:
             return std::make_unique<RollingByHourHelper>(dir_path_generator);
         case RecorderConfig::Rolling::kSize:
-            // Not supported currently
+            throw std::logic_error{"Record rolling by size is unsupported at present."};
         default:
-            throw std::logic_error{fmt::format("Unsupported record rolling strategy={}.", static_cast<int>(rolling))};
+            throw std::logic_error{
+                std::string{"Unknown record rolling strategy "} + std::to_string(static_cast<int>(rolling))};
     }
 }
 
 std::string GetRecordSubDirName(const RecorderConfig::Rolling rolling) {
     switch (rolling) {
         case RecorderConfig::Rolling::kNone:
-            return fmt::format("{}.pid.{}", GetCurrentUtcTime(), getpid());
         case RecorderConfig::Rolling::kDay:
-            return GetCurrentUtcDate();
         case RecorderConfig::Rolling::kHour:
-            return GetCurrentUtcHour();
+            return GetCurrentUtcTime() + ".UTC.pid." + std::to_string(getpid());
         case RecorderConfig::Rolling::kSize:
-            // Not supported currently
+            throw std::logic_error{"Record rolling by size is unsupported at present."};
         default:
-            throw std::logic_error{fmt::format("Unsupported record rolling strategy={}.", static_cast<int>(rolling))};
+            throw std::logic_error{
+                std::string{"Unknown record rolling strategy "} + std::to_string(static_cast<int>(rolling))};
     }
 }
 

--- a/src/msg_recorder/rolling_helper.h
+++ b/src/msg_recorder/rolling_helper.h
@@ -37,15 +37,25 @@ class RollingHelper {
 
 class RollingByDayHelper : public RollingHelper {
    public:
+    using TimePoint = Metadata::TimePoint;
+
     explicit RollingByDayHelper(const RecordDirPathGenerator* const dir_path_generator);
     ~RollingByDayHelper() override = default;
 
     bool NeedToRoll(const Metadata& metadata) const override;
 
-    void Update(const Metadata& metadata) override;
+    void Update(const Metadata&) override;
+
+    void Reset() override;
 
    protected:
-    Metadata::TimePoint last_write_time_{};
+    static TimePoint CalcNextRollingTime(const TimePoint now, const int interval_len, const int offset_seconds);
+
+    TimePoint time_to_roll_{};
+
+   private:
+    static constexpr long kSecondsPerDay =
+        (std::chrono::days::period::num + std::chrono::days::period::den - 1) / std::chrono::days::period::den;
 };
 
 class RollingByHourHelper : public RollingByDayHelper {
@@ -53,7 +63,11 @@ class RollingByHourHelper : public RollingByDayHelper {
     explicit RollingByHourHelper(const RecordDirPathGenerator* const dir_path_generator);
     ~RollingByHourHelper() override = default;
 
-    bool NeedToRoll(const Metadata& metadata) const override;
+    void Reset() override;
+
+   private:
+    static constexpr long kSecondsPerHour =
+        (std::chrono::hours::period::num + std::chrono::hours::period::den - 1) / std::chrono::hours::period::den;
 };
 
 class RollingBySizeHelper : public RollingHelper {

--- a/tests/record_file_rolling_test.cc
+++ b/tests/record_file_rolling_test.cc
@@ -47,7 +47,7 @@ TEST_F(RecordFileTestFixture, Symlink_OK) {
     EXPECT_TRUE(fs::is_directory(filepath));
     EXPECT_TRUE(record_file.IsOpen());
 
-    const fs::path linkpath = daily_rolling_dir_path_generator_() / linkname;
+    const fs::path linkpath = filepath.parent_path() / linkname;
     EXPECT_TRUE(fs::is_symlink(linkpath));
 }
 


### PR DESCRIPTION
Per comments in 
- https://github.com/cyfitech/cris-core/pull/207#issuecomment-1482874121

变更如下：
- Rolling目录不再使用日期（20230323）或者小时整点（2023032309），而是使用到秒级的时间戳 + pid
- 超过某个时间就执行roll（按天或者按小时均为00:01:00），而不是限定在整点切换时