### PR TITLE
macOS support for realpath.

### DIFF
--- a/scripts/bazel_pull.sh
+++ b/scripts/bazel_pull.sh
@@ -12,7 +12,7 @@ for cmd in base64 diff git grep sed xargs; do
 done
 
 git submodule foreach --recursive -q pwd            \
-| xargs -rI{} realpath --relative-to="$(pwd)" {}    \
+| xargs -rI{} "$(! uname -s | grep '^Darwin$' >/dev/null || printf 'g')realpath" --relative-to="$(pwd)" {}  \
 | sed 's/\/*$//'                                    \
 | grep -e'cris-'{base,xchg}'$'                      \
 | sort                                              \

--- a/scripts/format_all.sh
+++ b/scripts/format_all.sh
@@ -39,32 +39,32 @@ done
 
 # CRLF -> LF.
 # This should not be used on Windows.
-! which dos2unix >/dev/null 2>&1                                                                        \
-|| ls -1A                                                                                               \
-| grep -v '^\.git$'                                                                                     \
-| grep -v '^\.gitignore$'                                                                               \
-| sed 's/\r//g'                                                                                         \
-| tr '\n' '\0'                                                                                          \
-| $(which parallel >/dev/null 2>&1 && echo "parallel -j$(nproc) -m" || echo 'xargs -rI{}') -0           \
-    find {} -type f                                                                                     \
-| sed 's/\r//g'                                                                                         \
-| tr '\n' '\0'                                                                                          \
-| $(which parallel >/dev/null 2>&1 && echo "parallel -j$(nproc) -m" || echo 'xargs -r'   ) -0           \
-    grep -HI "$(printf '\r$')"                                                                          \
-| grep "$(printf ':.*\r$')"                                                                             \
-| cut -d: -f1                                                                                           \
-| grep -v $(set -e;                                                                                     \
-    which git >/dev/null                                                                                \
-    && git submodule foreach -q pwd                                                                     \
-    | xargs -rI{} realpath --relative-to="$(pwd)" {}                                                    \
-    | sed 's/\/*$/\//'                                                                                  \
-    | sed 's/\([\\\/\.\-]\)/\\\1/g'                                                                     \
-    | sed 's/^/\-e\^/'                                                                                  \
-    | grep .                                                                                            \
-    || echo '^$')                                                                                       \
-| sort -u                                                                                               \
-| sed 's/\r//g'                                                                                         \
-| tr '\n' '\0'                                                                                          \
+! which dos2unix >/dev/null 2>&1                                                                                \
+|| ls -1A                                                                                                       \
+| grep -v '^\.git$'                                                                                             \
+| grep -v '^\.gitignore$'                                                                                       \
+| sed 's/\r//g'                                                                                                 \
+| tr '\n' '\0'                                                                                                  \
+| $(which parallel >/dev/null 2>&1 && echo "parallel -j$(nproc) -m" || echo 'xargs -rI{}') -0                   \
+    find {} -type f                                                                                             \
+| sed 's/\r//g'                                                                                                 \
+| tr '\n' '\0'                                                                                                  \
+| $(which parallel >/dev/null 2>&1 && echo "parallel -j$(nproc) -m" || echo 'xargs -r'   ) -0                   \
+    grep -HI "$(printf '\r$')"                                                                                  \
+| grep "$(printf ':.*\r$')"                                                                                     \
+| cut -d: -f1                                                                                                   \
+| grep -v $(set -e;                                                                                             \
+    which git >/dev/null                                                                                        \
+    && git submodule foreach -q pwd                                                                             \
+    | xargs -rI{} "$(! uname -s | grep '^Darwin$' >/dev/null || printf 'g')realpath" --relative-to="$(pwd)" {}  \
+    | sed 's/\/*$/\//'                                                                                          \
+    | sed 's/\([\\\/\.\-]\)/\\\1/g'                                                                             \
+    | sed 's/^/\-e\^/'                                                                                          \
+    | grep .                                                                                                    \
+    || echo '^$')                                                                                               \
+| sort -u                                                                                                       \
+| sed 's/\r//g'                                                                                                 \
+| tr '\n' '\0'                                                                                                  \
 | $(which parallel >/dev/null 2>&1 && echo "parallel -j$(nproc) -m" || echo 'xargs -r'   ) -0 dos2unix -b -v
 
 # If Python formatter is not installed, install it

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -17,7 +17,7 @@ pushd "$(dirname "$0")/.." >/dev/null
 if which ccache >/dev/null 2>&1 && ([ -d 'run' ] && [ -w 'run' ] || [ -w '.' ]); then
     rm -rf 'run/toolchain'
     mkdir -p 'run/toolchain'
-    CR_CCACHE_CC_DIR="$(realpath -e "run/toolchain")"
+    CR_CCACHE_CC_DIR="$("$(! uname -s | grep '^Darwin$' >/dev/null || printf 'g')realpath" -e "run/toolchain")"
 
     for compiler_varname in "CC" "CXX"; do
         compiler="$(eval echo "\$$compiler_varname")"


### PR DESCRIPTION
macOS 13 is shipped with its BSD version of realpath, without `-e` and `-m`.
Route to grealpath installed by homebrew instead.