### PR TITLE
Use new record file path

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -84,6 +84,7 @@ cris_cc_library (
     include_prefix = "cris/core",
     strip_include_prefix = "src",
     deps = [
+        ":internal_msg_recorder_utils",
         ":utils",
     ],
     visibility = ["//visibility:private"],

--- a/src/msg_recorder/impl/utils.cc
+++ b/src/msg_recorder/impl/utils.cc
@@ -7,24 +7,24 @@ namespace fs = std::filesystem;
 
 namespace cris::core::impl {
 
-std::string GetMessageRecordFileName(const std::string& message_type, const CRMessageBase::channel_subid_t subid) {
-    auto       message_record_filename   = message_type;
-    const auto message_type_replace_pred = [](char c) {
+std::string GetMessageFileName(const std::string& message_type) {
+    auto       message_typename = message_type;
+    const auto replace_pred     = [](char c) {
         return !std::isalnum(c);
     };
-    std::replace_if(message_record_filename.begin(), message_record_filename.end(), message_type_replace_pred, '_');
-    return message_record_filename + "_subid_" + std::to_string(subid) + ".ldb.d";
+    std::replace_if(message_typename.begin(), message_typename.end(), replace_pred, '_');
+    return message_typename;
 }
 
-std::vector<fs::path> FindMatchedSubdirs(const fs::path& top_dir, const std::string_view dir_name) {
+std::vector<fs::path> ListSubdirsWithSuffix(const fs::path& top_dir, const std::string_view suffix) {
     std::vector<fs::path> matches;
 
     if (!fs::is_directory(top_dir)) {
         return matches;
     }
 
-    for (const auto& entry : fs::recursive_directory_iterator{top_dir}) {
-        if (fs::is_directory(entry) && entry.path().filename().native() == dir_name) {
+    for (const auto& entry : fs::directory_iterator{top_dir}) {
+        if (fs::is_directory(entry) && entry.path().filename().native().ends_with(suffix)) {
             matches.push_back(entry.path());
         }
     }

--- a/src/msg_recorder/impl/utils.h
+++ b/src/msg_recorder/impl/utils.h
@@ -9,10 +9,12 @@
 
 namespace cris::core::impl {
 
-std::string GetMessageRecordFileName(const std::string& message_type, const CRMessageBase::channel_subid_t subid);
+constexpr std::string_view kLevelDbDirSuffix = ".ldb.d";
 
-std::vector<std::filesystem::path> FindMatchedSubdirs(
+std::string GetMessageFileName(const std::string& message_type);
+
+std::vector<std::filesystem::path> ListSubdirsWithSuffix(
     const std::filesystem::path& top_dir,
-    const std::string_view       dir_name);
+    const std::string_view       suffix);
 
 }  // namespace cris::core::impl

--- a/src/msg_recorder/record_file.h
+++ b/src/msg_recorder/record_file.h
@@ -100,7 +100,7 @@ class RecordFile {
 
     bool IsOpen() const;
 
-    const std::string& GetFilePath() const;
+    const std::filesystem::path& GetFilePath() const;
 
     void Compact();
 
@@ -117,8 +117,7 @@ class RecordFile {
 
     bool Write(const std::string& key, const std::string& value) const;
 
-    std::string                    filepath_;
-    const std::string              filename_;
+    std::filesystem::path          filepath_;
     const std::string              linkname_;
     std::unique_ptr<RollingHelper> rolling_helper_;
     std::unique_ptr<leveldb::DB>   db_;
@@ -128,5 +127,9 @@ class RecordFile {
 bool MakeDirs(const std::filesystem::path& path);
 
 bool Symlink(const std::filesystem::path& to, const std::filesystem::path& from);
+
+bool IsEmptyDir(const std::string& path);
+
+bool IsLevelDBDir(const std::string& path);
 
 }  // namespace cris::core

--- a/src/msg_recorder/recorder.h
+++ b/src/msg_recorder/recorder.h
@@ -4,7 +4,6 @@
 #include "cris/core/msg/node.h"
 #include "cris/core/msg_recorder/record_file.h"
 #include "cris/core/msg_recorder/recorder_config.h"
-#include "cris/core/msg_recorder/rolling_helper.h"
 
 #include <atomic>
 #include <chrono>
@@ -31,13 +30,9 @@ struct SnapshotInfo {
 
 class MessageRecorder : public CRNamedNode<MessageRecorder> {
    public:
-    using Base                   = CRNamedNode<MessageRecorder>;
-    using RecordDirPathGenerator = RollingHelper::RecordDirPathGenerator;
+    using Base = CRNamedNode<MessageRecorder>;
 
-    explicit MessageRecorder(
-        RecorderConfig             recorder_config,
-        std::shared_ptr<JobRunner> runner,
-        RecordDirPathGenerator     dir_path_generator = {});
+    explicit MessageRecorder(RecorderConfig recorder_config, std::shared_ptr<JobRunner> runner);
 
     MessageRecorder(const MessageRecorder&) = delete;
     MessageRecorder(MessageRecorder&&)      = delete;
@@ -71,8 +66,6 @@ class MessageRecorder : public CRNamedNode<MessageRecorder> {
 
     RecordFile* CreateFile(const std::string& message_type, const channel_subid_t subid, const std::string& alias);
 
-    bool CheckRollingSettings() const;
-
     bool GenerateSnapshotImpl(const std::filesystem::path& snapshot_dir);
     void MaintainMaxNumOfSnapshots(const RecorderConfig::IntervalConfig& interval_config);
 
@@ -82,7 +75,6 @@ class MessageRecorder : public CRNamedNode<MessageRecorder> {
     static std::string SnapshotDirNameGenerator();
 
     const RecorderConfig                         recorder_config_;
-    RecordDirPathGenerator                       full_record_dir_path_generator_;
     std::vector<std::unique_ptr<RecordFile>>     files_;
     std::shared_ptr<cris::core::JobRunnerStrand> record_strand_;
 
@@ -106,10 +98,6 @@ void MessageRecorder::RegisterChannel(const MessageRecorder::channel_subid_t sub
         record_strand_);
 }
 
-std::unique_ptr<RollingHelper> CreateRollingHelper(
-    const RecorderConfig::Rolling                rolling,
-    const RollingHelper::RecordDirPathGenerator* dir_path_generator);
-
-std::string GetRecordSubDirName(const RecorderConfig::Rolling rolling);
+std::unique_ptr<RollingHelper> CreateRollingHelper(const RecorderConfig::Rolling rolling);
 
 }  // namespace cris::core

--- a/tests/record_file_rolling_test.cc
+++ b/tests/record_file_rolling_test.cc
@@ -7,8 +7,10 @@
 
 #include <gtest/gtest.h>
 
-#include <fmt/core.h>
+#include <unistd.h>
 
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -16,94 +18,115 @@ using namespace testing;
 
 namespace cris::core {
 
-namespace {
-constexpr std::string_view kHostname = "test-host";
-constexpr std::string_view kLocation = "test-location";
-}  // namespace
-
-class RecordFileTestFixture : public ::testing::Test {
+class RecordFileTestFixture : public Test {
    public:
     RecordFileTestFixture()
-        : temp_test_dir_{fs::temp_directory_path() / fmt::format("CRIS.record_file_rolling_test.{}", getpid())}
-        , daily_rolling_dir_path_generator_{[this] {
-            return GetTopDir() / GetRecordSubDirName(RecorderConfig::Rolling::kDay) / kHostname / kLocation;
-        }} {}
+        : sandbox_dir_{fs::temp_directory_path() / (std::string{"CRIS.record_rolling_test."} + std::to_string(getpid()))}
+        , record_dir_{sandbox_dir_ / "msg-type/subid"} {}
 
-    ~RecordFileTestFixture() override { fs::remove_all(GetTopDir()); }
+    ~RecordFileTestFixture() override { fs::remove_all(sandbox_dir_); }
 
-    const fs::path& GetTopDir() const { return temp_test_dir_; }
+    const fs::path& GetRecordDir() const { return record_dir_; }
 
    protected:
-    const fs::path                              temp_test_dir_;
-    const RollingHelper::RecordDirPathGenerator daily_rolling_dir_path_generator_;
+    const fs::path sandbox_dir_;
+    const fs::path record_dir_;
 };
 
 TEST_F(RecordFileTestFixture, Symlink_OK) {
-    const std::string filename = "dummy";
-    const std::string linkname = "link-to-dummy";
-    const fs::path    filepath = daily_rolling_dir_path_generator_() / filename;
+    const std::string filename = "20230323T010000";
+    const std::string linkname = "link-to-subid";
+    const fs::path    filepath = GetRecordDir() / filename;
     RecordFile        record_file{filepath.native(), linkname};
 
     EXPECT_TRUE(fs::is_directory(filepath));
     EXPECT_TRUE(record_file.IsOpen());
 
-    const fs::path linkpath = filepath.parent_path() / linkname;
+    const fs::path linkpath = sandbox_dir_ / linkname;
     EXPECT_TRUE(fs::is_symlink(linkpath));
+    EXPECT_EQ(fs::read_symlink(linkpath), "msg-type/subid")
+        << ": Symlink " << linkpath << " points to an unexpected path.";
+}
+
+TEST_F(RecordFileTestFixture, CloseDB_RemoveEmptyDB) {
+    const std::string filename    = "20230323T010000";
+    const std::string linkname    = "link-to-subid";
+    const fs::path    filepath    = GetRecordDir() / filename;
+    auto              record_file = std::make_unique<RecordFile>(filepath.native(), linkname);
+
+    EXPECT_TRUE(fs::is_directory(filepath));
+    EXPECT_TRUE(record_file->IsOpen());
+
+    record_file.reset();
+    EXPECT_FALSE(fs::exists(filepath));
+    EXPECT_TRUE(fs::exists(filepath.parent_path()));
+}
+
+TEST_F(RecordFileTestFixture, CloseDB_KeepNonEmptyDB) {
+    const std::string filename    = "20230323T010000";
+    const std::string linkname    = "link-to-subid";
+    const fs::path    filepath    = GetRecordDir() / filename;
+    auto              record_file = std::make_unique<RecordFile>(filepath.native(), linkname);
+
+    EXPECT_TRUE(fs::is_directory(filepath));
+    EXPECT_TRUE(record_file->IsOpen());
+
+    record_file->Write("abc");
+
+    record_file.reset();
+    EXPECT_TRUE(fs::exists(filepath));
 }
 
 class MockRollingHelper : public RollingHelper {
    public:
-    explicit MockRollingHelper(const RecordDirPathGenerator* const dir_path_maker) : RollingHelper{dir_path_maker} {}
-
     MOCK_METHOD(bool, NeedToRoll, (const Metadata& metadata), (const, override));
     MOCK_METHOD(void, Update, (const Metadata& metadata), (override));
     MOCK_METHOD(void, Reset, (), (override));
-    MOCK_METHOD(std::filesystem::path, GenerateFullRecordDirPath, (), (const));
+    MOCK_METHOD(std::string, MakeNewRecordDirName, (), (const, override));
 };
 
 TEST_F(RecordFileTestFixture, NoNeedToRoll_OK) {
-    const std::string filename = "dummy";
-    const std::string linkname = "link-to-dummy";
-    const fs::path    filepath = daily_rolling_dir_path_generator_() / filename;
+    const std::string filename = "20230323T010000";
+    const std::string linkname = "link-to-subid";
+    const fs::path    filepath = GetRecordDir() / filename;
 
-    auto  mock_rolling_helper_ptr = std::make_unique<MockRollingHelper>(&daily_rolling_dir_path_generator_);
+    auto  mock_rolling_helper_ptr = std::make_unique<MockRollingHelper>();
     auto& mock_rolling_helper     = *mock_rolling_helper_ptr;
 
     EXPECT_CALL(mock_rolling_helper, NeedToRoll(_)).Times(1).WillOnce(Return(false));
     EXPECT_CALL(mock_rolling_helper, Update(_)).Times(1);
     EXPECT_CALL(mock_rolling_helper, Reset()).Times(0);
-    EXPECT_CALL(mock_rolling_helper, GenerateFullRecordDirPath()).Times(0);
+    EXPECT_CALL(mock_rolling_helper, MakeNewRecordDirName()).Times(0);
 
     RecordFile record_file{filepath.native(), linkname, std::move(mock_rolling_helper_ptr)};
     record_file.Write("abc");
-    EXPECT_EQ(filepath.native(), record_file.GetFilePath());
+    EXPECT_EQ(filepath, record_file.GetFilePath());
 }
 
 TEST_F(RecordFileTestFixture, Roll_OK) {
-    const std::string filename     = "dummy";
-    const std::string linkname     = "link-to-dummy";
-    const fs::path    filepath     = daily_rolling_dir_path_generator_() / filename;
-    const fs::path    next_dirpath = GetTopDir() / "rolling-next";
+    const std::string filename      = "20230323T010000";
+    const std::string linkname      = "link-to-subid";
+    const fs::path    filepath      = GetRecordDir() / filename;
+    const fs::path    next_filepath = GetRecordDir() / "20230324T010000";
 
-    auto  mock_rolling_helper_ptr = std::make_unique<MockRollingHelper>(&daily_rolling_dir_path_generator_);
+    auto  mock_rolling_helper_ptr = std::make_unique<MockRollingHelper>();
     auto& mock_rolling_helper     = *mock_rolling_helper_ptr;
 
     EXPECT_CALL(mock_rolling_helper, NeedToRoll(_)).Times(1).WillOnce(Return(true));
     EXPECT_CALL(mock_rolling_helper, Update(_)).Times(1);
     EXPECT_CALL(mock_rolling_helper, Reset()).Times(1);
-    EXPECT_CALL(mock_rolling_helper, GenerateFullRecordDirPath()).Times(1).WillOnce(Return(next_dirpath));
+    EXPECT_CALL(mock_rolling_helper, MakeNewRecordDirName()).Times(1).WillOnce(Return(next_filepath.native()));
 
     constexpr std::string_view value{"abc"};
     RecordFile                 record_file{filepath.native(), linkname, std::move(mock_rolling_helper_ptr)};
     const auto                 key = RecordFileKey::Make();
     record_file.Write(key, std::string{value});
 
-    const fs::path latest_record_path = next_dirpath / filename;
-    EXPECT_TRUE(fs::is_directory(latest_record_path));
-    EXPECT_TRUE(fs::is_symlink(next_dirpath / linkname));
+    // Old DB is empty, expected to be removed
+    EXPECT_FALSE(fs::exists(filepath));
+    EXPECT_TRUE(fs::is_directory(next_filepath));
 
-    const std::string expected_filepath = fs::path{next_dirpath / filename}.native();
-    EXPECT_EQ(expected_filepath, record_file.GetFilePath());
+    EXPECT_EQ(next_filepath, record_file.GetFilePath());
     EXPECT_TRUE(record_file.IsOpen());
     EXPECT_FALSE(record_file.Empty());
 


### PR DESCRIPTION
使用下面的comment的record file路径
- https://github.com/cyfitech/cris-base/issues/146#issuecomment-1481896514

BTW, 有一点区别，`record_dir / hostname / time.pid` => `record_dir / time.pid / hostname` 

### Sample

Non Rolling
```sh
tree mains/record_test/20230330T054209.UTC.pid.1439817/HOST                                                             
mains/record_test/20230330T054209.UTC.pid.1439817/HOST
├── MESSAGE__DepthMarketData_
│   └── SUBID
│       └── 20230330T054209.ldb.d
├── MESSAGE__ProcessedMarketData_
│   └── SUBID
│       └── 20230330T054209.ldb.d
├── MESSAGE__TradeMarketData_
│   └── SUBID
│       └── 20230330T054209.ldb.d
├── XCHG__SYMBOL__Depth -> MESSAGE__DepthMarketData_/SUBID
├── XCHG__SYMBOL__Processed -> MESSAGE__ProcessedMarketData_/SUBID
└── XCHG__SYMBOL__Trade -> MESSAGE__TradeMarketData_/SUBID
```

Rolling
```sh
tree mains/record_test/20230330T054525.UTC.pid.1440002/HOST
mains/record_test/20230330T054525.UTC.pid.1440002/HOST
├── MESSAGE__DepthMarketData_
│   └── SUBID
│       ├── 20230330T054525.ldb.d
│       └── 20230330T060100.ldb.d
├── MESSAGE__ProcessedMarketData_
│   └── SUBID
│       ├── 20230330T054525.ldb.d
│       └── 20230330T060102.ldb.d
├── MESSAGE__TradeMarketData_
│   └── SUBID
│       ├── 20230330T054525.ldb.d
│       └── 20230330T060108.ldb.d
├── XCHG__SYMBOL__Depth -> MESSAGE__DepthMarketData_/SUBID
├── XCHG__SYMBOL__Processed -> MESSAGE__ProcessedMarketData_/SUBID
└── XCHG__SYMBOL__Trade -> MESSAGE__TradeMarketData_/SUBID
```