### PR TITLE
Build libfmt with `-fPIC`

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -153,6 +153,7 @@ cmake(
     cache_entries = {
         "CMAKE_C_FLAGS" : "-Wno-fuse-ld-path",
         "CMAKE_CXX_FLAGS" : "-Wno-fuse-ld-path",
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
         "FMT_MASTER_PROJECT": "OFF",
         "FMT_INSTALL": "ON",
     },


### PR DESCRIPTION
Fix sanitizer test build fails
https://github.com/cyfitech/cris/actions/runs/4572411789/jobs/8071638327#step:5:5678
```
ERROR: /__w/cris/cris/libs/backtest/BUILD:120:17: Linking libs/backtest/cris_backtest.so failed: (Exit 1): clang-13-wrapper failed: error executing command (from target //libs/backtest:cris_backtest.so) /__w/cris/cris/run/toolchain/clang-13-wrapper @bazel-out/k8-opt/bin/libs/backtest/cris_backtest.so-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld.lld: error: can't create dynamic relocation R_X86_64_32 against symbol: stderr in readonly segment; recompile object files with -fPIC or pass '-Wl,-z,notext' to allow text relocations in the output
>>> defined in /lib/x86_64-linux-gnu/libc.so.6
>>> referenced by format.cc
>>>               format.cc.o:(fmt::v8::detail::assert_fail(char const*, int, char const*)) in archive bazel-out/k8-opt/bin/external/fmt/libfmt/lib/libfmt.a
```