### PR TITLE
[tidy] Treat tidy bugprone-exception-escape warning as error

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,7 +68,6 @@ CheckOptions:
 
 WarningsAsErrors: >
     *,
-    -bugprone-exception-escape,
     -clang-diagnostic-deprecated-builtins,
     -clang-diagnostic-deprecated-declarations,
     -clang-diagnostic-sign-conversion,


### PR DESCRIPTION
Update clang-tidy rules
- For functions that should not throw exception, report error if they may throw exception

Reference
- https://clang.llvm.org/extra/clang-tidy/checks/bugprone/exception-escape.html


Per comment
- https://github.com/cyfitech/cris-core/pull/217#pullrequestreview-1370200207