### PR TITLE
Separating Join from JobRunner::Stop

### DIFF
--- a/benchmarks/job_runner_benchmark.cc
+++ b/benchmarks/job_runner_benchmark.cc
@@ -12,7 +12,7 @@ static void BM_AddJob(benchmark::State& state) {
     for ([[maybe_unused]] const auto s : state) {
         job_runner->AddJob([]() {});
     }
-    job_runner->Stop();
+    job_runner->Stop().Join();
 }
 
 static void BM_AddJobBatch(benchmark::State& state) {
@@ -28,7 +28,7 @@ static void BM_AddJobBatch(benchmark::State& state) {
 
         job_runner->AddJobs(std::move(job_batch));
     }
-    job_runner->Stop();
+    job_runner->Stop().Join();
 }
 
 static void BM_AddJobWithStrand(benchmark::State& state) {
@@ -37,7 +37,7 @@ static void BM_AddJobWithStrand(benchmark::State& state) {
     for ([[maybe_unused]] const auto s : state) {
         job_runner->AddJob([]() {}, strand);
     }
-    job_runner->Stop();
+    job_runner->Stop().Join();
 }
 
 static void BM_AddJobTryImmediately(benchmark::State& state) {
@@ -46,7 +46,7 @@ static void BM_AddJobTryImmediately(benchmark::State& state) {
     for ([[maybe_unused]] const auto s : state) {
         job_runner->AddJob([]() {}, strand, JobRunner::TryRunImmediately());
     }
-    job_runner->Stop();
+    job_runner->Stop().Join();
 }
 
 BENCHMARK(BM_AddJob)->ThreadRange(1, 4);

--- a/src/sched/job_runner.cc
+++ b/src/sched/job_runner.cc
@@ -231,7 +231,7 @@ JobRunner::JobRunner(JobRunner::Config config) : config_(config) {
 
 JobRunner::~JobRunner() {
     ready_for_stealing_.store(false);
-    Stop();
+    Stop().Join();
 }
 
 JobRunnerStrandPtr JobRunner::MakeStrand() {
@@ -354,12 +354,21 @@ bool JobRunner::Steal() {
     return false;
 }
 
-void JobRunner::Stop() {
+JobRunner& JobRunner::Stop() {
     for (auto& worker : workers_) {
         if (!worker) {
             continue;
         }
         worker->Stop();
+    }
+    return *this;
+}
+
+void JobRunner::Join() {
+    for (auto& worker : workers_) {
+        if (!worker) {
+            continue;
+        }
         worker->Join();
     }
 }

--- a/src/sched/job_runner.h
+++ b/src/sched/job_runner.h
@@ -100,7 +100,9 @@ class JobRunner : public std::enable_shared_from_this<JobRunner> {
     /// @return true if any job was stolen
     bool Steal();
 
-    void Stop();
+    JobRunner& Stop();
+
+    void Join();
 
     void NotifyOneWorker();
 


### PR DESCRIPTION
Sometimes we only want to trigger stop, but do not want to join immediately. That is why we should separate `Join` from `Stop`. The original `Stop()` can be replaced by `Stop().Join()`.