### PR TITLE
Upgrade Dockerfile for Debian 12 Bookworm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -190,8 +190,9 @@ RUN set -e; \
                 dstat \
                 expect \
                 findutils \
-                g{cc,++}-10 \
-                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-22\.04$' >/dev/null || echo g{cc,++}-12) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[024]\.04$' -e'^debian\-11' >/dev/null || echo g{cc,++}-10) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[24]\.04$'  -e'^debian\-12' >/dev/null || echo g{cc,++}-11) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[24]\.04$'  -e'^debian\-12' >/dev/null || echo g{cc,++}-12) \
                 gdb \
                 git{,-{extras,lfs}} \
                 gzip \
@@ -207,20 +208,20 @@ RUN set -e; \
                 lib{asan6,lsan0,tsan0,ubsan1} \
                 $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-22\.04$' >/dev/null || echo lib{asan8,tsan2}) \
                 lib{benchmark,boost-all,curl4-openssl,edit,eigen3,event,gflags,gmp,gtest,hiredis,hwloc,leveldb,lmdb,lzma,mpfr,mpc,ncurses5,rocksdb,snappy,ssl,tbb}-dev \
-                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^debian\-11$'     >/dev/null || echo libc++{,abi}-11-dev lldb-11) \
-                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-20\.04$' >/dev/null || echo libc++{,abi}-12-dev lldb-12) \
-                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-22\.04$' >/dev/null || echo libc++{,abi}-14-dev lldb-14) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^debian\-11$'                      >/dev/null || echo libc++{,abi}-11-dev lldb-11) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-20\.04$'                  >/dev/null || echo libc++{,abi}-12-dev lldb-12) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-22\.04$' -e'^debian\-12$' >/dev/null || echo libc++{,abi}-14-dev lldb-14) \
                 liblz4-dev liblz4-tool \
                 $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-20\.04$' >/dev/null || echo libomp-10-dev libomp5-10) \
                 $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^debian\-11$'     >/dev/null || echo libomp-13-dev libomp5-13) \
                 $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-22\.04$' >/dev/null || echo libomp-14-dev libomp5-14) \
                 libpapi-dev papi-tools \
                 libtool \
-                llvm-11{,-tools} {clang{,-{format,tidy,tools}},lld}-11 \
-                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[02]\.04$'  >/dev/null || echo llvm-12{,-tools} {clang{,-{format,tidy,tools}},lld}-12) \
-                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[024]\.04$' >/dev/null || echo llvm-13{,-tools} {clang{,-{format,tidy,tools}},lld}-13) \
-                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^debian\-1[12]$'      >/dev/null || echo llvm-13{,-tools} {clang{,-{format,tidy,tools}},lld}-13) \
-                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[24]\.04$'  >/dev/null || echo llvm-14{,-tools} {clang{,-{format,tidy,tools}},lld}-14) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[02]\.04$'  -e'^debian\-11$'   >/dev/null || echo llvm-11{,-tools} {clang{,-{format,tidy,tools}},lld}-11) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[02]\.04$'                     >/dev/null || echo llvm-12{,-tools} {clang{,-{format,tidy,tools}},lld}-12) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[024]\.04$' -e'^debian\-1[12]$'>/dev/null || echo llvm-13{,-tools} {clang{,-{format,tidy,tools}},lld}-13) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[24]\.04$'  -e'^debian\-12$'   >/dev/null || echo llvm-14{,-tools} {clang{,-{format,tidy,tools}},lld}-14) \
+                $(! echo "$DISTRO_ID-$DISTRO_VERSION_ID" | grep -e'^ubuntu\-2[24]\.04$'  -e'^debian\-12$'   >/dev/null || echo llvm-15{,-tools} {clang{,-{format,tidy,tools}},lld}-15) \
                 locales \
                 locate \
                 lshw \
@@ -281,17 +282,31 @@ RUN set -e; \
     git clone https://github.com/xkszltl/roaster.git /etc/roaster/scripts; \
     truncate -s0 ~/.bash_history;
 
+# [PEP 668](https://peps.python.org/pep-0668/) disallows installing pip packages directly to the base environment.
+# However, there are no viable alternatives, so we set `--break-system-package` as a workaround.
 RUN set -e; \
+    PIP_MAYBE_BREAK_SYSTEM_PACKAGES="$(set -e; \
+        OPT="--break-system-packages"; \
+        python3 -m pip install --help \
+        | sed 's/^/ /' \
+        | sed 's/$/ /' \
+        | grep -q "[^[:alnum:]_-]$OPT[^[:alnum:]_-]" \
+        && printf '%s' "$OPT" \
+        || true)"; \
     PIP_INDEX_URL="$(ROOT_DIR=/etc/roaster/scripts . /etc/roaster/scripts/geo/pip-mirror.sh >&2 && printf '%s' "$PIP_INDEX_URL")"; \
     export PIP_MAX_ATTEMPT=3; \
     for attempt in $(seq "$PIP_MAX_ATTEMPT" -1 0); do \
         [ "$attempt" -gt 0 ]; \
-        sudo PIP_INDEX_URL="$PIP_INDEX_URL" python3 -m pip install -U pip wheel setuptools && break; \
+        sudo PIP_INDEX_URL="$PIP_INDEX_URL" python3 -m pip install -U $PIP_MAYBE_BREAK_SYSTEM_PACKAGES \
+            pip \
+            wheel \
+            setuptools \
+        && break; \
         echo "Retrying... $(expr "$attempt" - 1) chance(s) left."; \
     done; \
     for attempt in $(seq "$PIP_MAX_ATTEMPT" -1 0); do \
         [ "$attempt" -gt 0 ]; \
-        sudo PIP_INDEX_URL="$PIP_INDEX_URL" python3 -m pip install -U \
+        sudo PIP_INDEX_URL="$PIP_INDEX_URL" python3 -m pip install -U $PIP_MAYBE_BREAK_SYSTEM_PACKAGES \
             black \
             flake8 \
             isort \
@@ -301,10 +316,6 @@ RUN set -e; \
     rm -rf ~/.cache/pip; \
     truncate -s0 ~/.bash_history;
 
-# TODO(chenhao94) Build packages for arm64.
-#
-# For now we only build packages for amd64 because CI is running on amd64 machines.
-# Otherwise it will be too slow for CI to build docker images on ARM emulation.
 RUN set -e; \
     export CRIS_IMG_ARCH="$(set -e; \
         case "$(uname -m)" in \


### PR DESCRIPTION
Tested with Debian sid as the base image, and build our entire codebase by GCC 12 and Clang 15 on the locally generated CRIS Debian 12 (sid) image.