### PR TITLE
RAII for PAPI to use hardware counters.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -23,6 +23,14 @@ cris_cc_library (
     hdrs = glob(["src/utils/**/*.h"]),
     include_prefix = "cris/core",
     strip_include_prefix = "src",
+    copts = select({
+        "@platforms//os:macos": [""],
+        "//conditions:default": ["-DCRIS_USE_PAPI"],
+    }),
+    linkopts = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["-lpapi"],
+    }),
     deps = [
         "@com_github_google_glog//:glog",
         "@fmt//:libfmt",

--- a/src/utils/papi.cc
+++ b/src/utils/papi.cc
@@ -1,0 +1,187 @@
+#include "cris/core/utils/papi.h"
+
+#include "cris/core/utils/logging.h"
+
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+
+using namespace std;
+
+namespace cris::core {
+
+PAPIStat::PAPIStat() {
+    if (!enabled_) {
+        return;
+    }
+#if defined(CRIS_USE_PAPI) && CRIS_USE_PAPI
+    {
+        const int err = PAPI_create_eventset(&event_set_);
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI failed (" << err << ") to create event set.";
+            enabled_ = false;
+            return;
+        }
+    }
+    {
+        const int err = PAPI_assign_eventset_component(event_set_, 0);
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI failed (" << err << ") to bind event set to CPU.";
+            enabled_ = false;
+            return;
+        }
+    }
+    {
+        const int err = PAPI_set_multiplex(event_set_);
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI failed (" << err << ") to create multiplex event set.";
+            enabled_ = false;
+            return;
+        }
+    }
+    {
+        const int err = PAPI_add_events(event_set_, papi_events_.data(), static_cast<int>(papi_events_.size()));
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI failed (" << err << ") to add event(s).";
+            enabled_ = false;
+            return;
+        }
+    }
+#else
+    LOG(WARNING) << "PAPI is disabled in build.";
+#endif
+    Start();
+}
+
+PAPIStat::~PAPIStat() {
+    Stop();
+#if defined(CRIS_USE_PAPI) && CRIS_USE_PAPI
+    if (event_set_ != PAPI_NULL) {
+        const int err = PAPI_destroy_eventset(&event_set_);
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI failed (" << err << ") to free the event set.";
+            enabled_ = false;
+            return;
+        }
+    }
+#endif
+    if (auto_print_) {
+        LOG(INFO) << operator string();
+    }
+}
+
+void PAPIStat::Start() {
+    if (!enabled_) {
+        return;
+    }
+#if defined(CRIS_USE_PAPI) && CRIS_USE_PAPI
+    CHECK_EQ(PAPI_start(event_set_), PAPI_OK) << "PAPI failed to start." << endl;
+#endif
+}
+
+void PAPIStat::Stop() {
+#if defined(CRIS_USE_PAPI) && CRIS_USE_PAPI
+    if (enabled_) {
+        const int err = PAPI_stop(event_set_, values_.data());
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI failed (" << err << ") to stop.";
+            enabled_ = false;
+            return;
+        }
+    }
+    if (event_set_ != PAPI_NULL) {
+        const int err = PAPI_cleanup_eventset(event_set_);
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI failed (" << err << ") to clean up the event set.";
+            enabled_ = false;
+            return;
+        }
+    }
+#endif
+}
+
+void PAPIStat::Reset() {
+    Stop();
+    Start();
+}
+
+PAPIStat::operator string() {
+    if (!enabled_) {
+        return "PAPI disabled.";
+    }
+    buf_.clear();
+    buf_.str("");
+    buf_ << "PAPI summary:" << endl;
+    buf_ << "    L1/2/3 cache misses:  " << values_[0] << " " << values_[1] << " " << values_[2] << endl;
+    buf_ << "    Data/Inst TLB misses: " << values_[3] << " " << values_[4] << endl;
+    buf_ << "    Stall on write/total: " << values_[5] << " " << values_[6];
+    auto summary = buf_.str();
+    buf_.clear();
+    buf_.str("");
+    return summary;
+}
+
+unsigned long PAPIStat::get_tid() {
+    ostringstream buf;
+    buf << this_thread::get_id();
+    try {
+        return static_cast<unsigned long>(stoul(buf.str()));
+    } catch (const invalid_argument& ex) {
+        LOG(WARNING) << "Cannot retrieve numerical thread id from \"" << buf.str()
+                     << "\" to enable PAPI threading support.";
+    } catch (const out_of_range& ex) {
+        LOG(WARNING) << "Cannot retrieve numerical thread id from \"" << buf.str()
+                     << "\" to enable PAPI threading support.";
+    }
+    return 0;
+}
+
+atomic<bool> PAPIStat::enabled_ = []() {
+#if defined(CRIS_USE_PAPI) && CRIS_USE_PAPI
+    {
+        const int ver = PAPI_library_init(PAPI_VER_CURRENT);
+        if (ver != static_cast<int>(PAPI_VER_CURRENT)) {
+            LOG(WARNING) << "PAPI has already been initialized by another version instead of \"" << PAPI_VER_CURRENT
+                         << "\".";
+            return false;
+        }
+    }
+    {
+        const int err = PAPI_multiplex_init();
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI disabled after failure (" << err << ") of init counter multiplexing.";
+            return false;
+        }
+    }
+    {
+        const int err = PAPI_thread_init(get_tid);
+        if (err != PAPI_OK) {
+            LOG(WARNING) << "PAPI failed (" << err << ") to initialize threading support.";
+            return false;
+        }
+    }
+    {
+        // A misaligned 7ms within typical time slice.
+        static PAPI_option_t mpx_opt{
+            .multiplex = PAPI_multiplex_option_t{
+                .eventset = 0,
+                .ns       = 7654321,
+                .flags    = 0,
+            }};
+        // TODO(xkszltl): Somehow the option cannot be set.
+        // NOLINTNEXTLINE(readability-simplify-boolean-expr,-warnings-as-errors)
+        if constexpr (false) {
+            const int err = PAPI_set_opt(PAPI_DEF_MPX_NS, &mpx_opt);
+            if (err != PAPI_OK) {
+                LOG(WARNING) << "PAPI failed to set multiplexing options.";
+                return false;
+            }
+        }
+    }
+    return true;
+#else
+    return false;
+#endif
+}();
+
+}  // namespace cris::core

--- a/src/utils/papi.h
+++ b/src/utils/papi.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#if defined(CRIS_USE_PAPI) && CRIS_USE_PAPI
+#if defined(__has_include) && __has_include(<papi.h>)
+#include <papi.h>
+#else
+#undef CRIS_USE_PAPI
+#endif
+#endif
+
+#include <atomic>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace cris::core {
+
+class PAPIStat {
+   public:
+    template<typename T>
+    using atomic = std::atomic<T>;
+
+    using string = std::string;
+
+    using ostringstream = std::ostringstream;
+
+    template<typename T>
+    using vector = std::vector<T>;
+
+    using Self = PAPIStat;
+
+    PAPIStat();
+    ~PAPIStat();
+
+    void Start();
+    void Stop();
+    void Reset();
+
+    explicit operator string();
+
+    // These are inmuutable but C API does not allow const.
+    vector<int> papi_events_ = vector<int> {
+#if defined(CRIS_USE_PAPI) && CRIS_USE_PAPI
+        PAPI_L1_TCM, PAPI_L2_TCM, PAPI_L3_TCM, PAPI_TLB_DM, PAPI_TLB_IM, PAPI_MEM_WCY, PAPI_RES_STL,
+#endif
+    };
+    vector<long long> values_ = vector<long long>(papi_events_.size());
+
+    bool auto_print_ = true;
+
+    static atomic<bool> enabled_;
+
+   protected:
+    static unsigned long get_tid();
+
+    int event_set_ =
+#if defined(CRIS_USE_PAPI) && CRIS_USE_PAPI
+        PAPI_NULL;
+#else
+        0;
+#endif
+
+    ostringstream buf_;
+};
+
+}  // namespace cris::core

--- a/src/utils/time.cc
+++ b/src/utils/time.cc
@@ -32,7 +32,7 @@
 
 namespace cris::core {
 
-static const double kTscToNsecRatio = []() {
+const double kTscToNsecRatio = []() {
     constexpr auto kCalibrationDuration = std::chrono::seconds(1);
 
     unsigned cpuid = 0;

--- a/src/utils/time.h
+++ b/src/utils/time.h
@@ -9,6 +9,8 @@ namespace cris::core {
 using cr_timestamp_nsec_t = std::int64_t;
 using cr_duration_nsec_t  = std::int64_t;
 
+extern const double kTscToNsecRatio;
+
 // CPU Time Stamp Counter tick.
 unsigned long long GetTSCTick(unsigned& aux);
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -11,6 +11,16 @@ cris_cc_library(
 )
 
 cris_cc_test (
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    deps = [
+        "//:config",
+        "@fmt//:libfmt",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+
+cris_cc_test (
     name = "defs_test",
     srcs = ["defs_test.cc"],
     deps = [
@@ -19,18 +29,49 @@ cris_cc_test (
     ],
 )
 
+filegroup(
+    name = "job_queue_tsan_suppressions",
+    srcs = ["job_queue_tsan_suppressions.txt"],
+)
+
 cris_cc_test (
-    name = "mapping_test",
-    srcs = ["mapping_test.cc"],
+    name = "job_queue_test",
+    srcs = ["job_queue_test.cc"],
+    env = {
+        "TSAN_OPTIONS": "suppressions=$(execpath job_queue_tsan_suppressions)",
+    },
+    data = [
+        ":job_queue_tsan_suppressions",
+    ],
     deps = [
-        "//:utils",
+        "//:sched",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+
+filegroup(
+    name = "job_runner_tsan_suppressions",
+    srcs = ["job_runner_tsan_suppressions.txt"],
+)
+
+cris_cc_test (
+    name = "job_runner_test",
+    srcs = ["job_runner_test.cc"],
+    env = {
+        "TSAN_OPTIONS": "suppressions=$(execpath job_runner_tsan_suppressions)",
+    },
+    data = [
+        ":job_runner_tsan_suppressions",
+    ],
+    deps = [
+        "//:sched",
         "@cris-core//tests:cris_gtest_main",
     ],
 )
 
 cris_cc_test (
-    name = "time_test",
-    srcs = ["time_test.cc"],
+    name = "mapping_test",
+    srcs = ["mapping_test.cc"],
     deps = [
         "//:utils",
         "@cris-core//tests:cris_gtest_main",
@@ -54,6 +95,30 @@ cris_cc_test (
         "@cris-core//tests:cris_gtest_main",
     ],
     flaky = True,
+)
+
+cris_cc_test (
+    name = "node_test",
+    srcs = ["node_test.cc"],
+    env = {
+        "TSAN_OPTIONS": "suppressions=$(execpath job_runner_tsan_suppressions)",
+    },
+    data = [
+        ":job_runner_tsan_suppressions",
+    ],
+    deps = [
+        "//:msg",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+
+cris_cc_test (
+    name = "papi_test",
+    srcs = ["papi_test.cc"],
+    deps = [
+        "//:utils",
+        "@cris-core//tests:cris_gtest_main",
+    ],
 )
 
 cris_cc_test (
@@ -102,80 +167,6 @@ cris_cc_test (
 # )
 
 cris_cc_test (
-    name = "node_test",
-    srcs = ["node_test.cc"],
-    env = {
-        "TSAN_OPTIONS": "suppressions=$(execpath job_runner_tsan_suppressions)",
-    },
-    data = [
-        ":job_runner_tsan_suppressions",
-    ],
-    deps = [
-        "//:msg",
-        "@cris-core//tests:cris_gtest_main",
-    ],
-)
-
-cris_cc_test (
-    name = "timer_test",
-    srcs = ["timer_test.cc"],
-    deps = [
-        "//:timer",
-        "@cris-core//tests:cris_gtest_main",
-    ],
-)
-
-filegroup(
-    name = "job_runner_tsan_suppressions",
-    srcs = ["job_runner_tsan_suppressions.txt"],
-)
-
-cris_cc_test (
-    name = "job_runner_test",
-    srcs = ["job_runner_test.cc"],
-    env = {
-        "TSAN_OPTIONS": "suppressions=$(execpath job_runner_tsan_suppressions)",
-    },
-    data = [
-        ":job_runner_tsan_suppressions",
-    ],
-    deps = [
-        "//:sched",
-        "@cris-core//tests:cris_gtest_main",
-    ],
-)
-
-filegroup(
-    name = "job_queue_tsan_suppressions",
-    srcs = ["job_queue_tsan_suppressions.txt"],
-)
-
-cris_cc_test (
-    name = "job_queue_test",
-    srcs = ["job_queue_test.cc"],
-    env = {
-        "TSAN_OPTIONS": "suppressions=$(execpath job_queue_tsan_suppressions)",
-    },
-    data = [
-        ":job_queue_tsan_suppressions",
-    ],
-    deps = [
-        "//:sched",
-        "@cris-core//tests:cris_gtest_main",
-    ],
-)
-
-cris_cc_test (
-    name = "config_test",
-    srcs = ["config_test.cc"],
-    deps = [
-        "//:config",
-        "@fmt//:libfmt",
-        "@cris-core//tests:cris_gtest_main",
-    ],
-)
-
-cris_cc_test (
     name = "record_key_test",
     srcs = ["record_key_test.cc"],
     deps = [
@@ -209,6 +200,24 @@ cris_cc_test (
     srcs = ["stacktrace_test.cc"],
     deps = [
         "//:signal",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+
+cris_cc_test (
+    name = "time_test",
+    srcs = ["time_test.cc"],
+    deps = [
+        "//:utils",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+
+cris_cc_test (
+    name = "timer_test",
+    srcs = ["timer_test.cc"],
+    deps = [
+        "//:timer",
         "@cris-core//tests:cris_gtest_main",
     ],
 )

--- a/tests/papi_test.cc
+++ b/tests/papi_test.cc
@@ -1,0 +1,40 @@
+#include "cris/core/utils/papi.h"
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <vector>
+
+using namespace std;
+
+namespace cris::core {
+
+/* Disable for ASAN due to a known leak in PAPI.
+ * - https://sourceforge.net/p/perfmon2/bugs/17/
+ * - https://github.com/cyfitech/cris-core/pull/226
+ *
+ * TODO(xkszltl): Suppress warnings from PAPI instead.
+ */
+#ifdef __has_feature
+#if !__has_feature(address_sanitizer)
+TEST(PAPI, RAII) {
+    PAPIStat();
+}
+
+TEST(PAPI, Long) {
+    const PAPIStat stat;
+
+    const int        round = 100000000;
+    vector<unsigned> dat(round);
+    iota(dat.begin(), dat.end(), 0);
+
+    unsigned acc = 0;
+    for (const auto i : dat) {
+        acc += dat[i] * 3;
+    }
+    EXPECT_EQ(acc, static_cast<unsigned>((static_cast<long long>(round - 1) * round / 2 * 3) & 0xFFFFFFFFll));
+}
+#endif
+#endif
+
+}  // namespace cris::core


### PR DESCRIPTION
Also re-sort the BUILD file.

Covered in unit test:
```
Running main() from tests/utils/cris_gtest_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from PAPI
[ RUN      ] PAPI.RAII
WARNING: Logging before InitGoogleLogging() is written to STDERR
I20230620 20:18:05.109184 19191 papi.cc:59] PAPI summary:
    L1/2/3 cache misses:  172 57 48
    Data/Inst TLB misses: 0 0
    Stall on write/total: 0 0
[       OK ] PAPI.RAII (0 ms)
[ RUN      ] PAPI.Long
I20230620 20:18:05.226078 19191 papi.cc:59] PAPI summary:
    L1/2/3 cache misses:  18764743 11963172 11810402
    Data/Inst TLB misses: 9627 11
    Stall on write/total: 135847225 189858892
[       OK ] PAPI.Long (116 ms)
[----------] 2 tests from PAPI (117 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (117 ms total)
[  PASSED  ] 2 tests.
```

Beware the trailing 0s are probably due to multiplexing error in this kind of short test, not because they are actually 0.