### PR TITLE
Track execution timeline in details.

### DIFF
--- a/src/utils/timeline.cc
+++ b/src/utils/timeline.cc
@@ -1,0 +1,193 @@
+#include "cris/core/utils/timeline.h"
+
+#include "cris/core/utils/defs.h"
+#include "cris/core/utils/logging.h"
+#include "cris/core/utils/time.h"
+
+#include <algorithm>
+#include <cmath>
+#include <deque>
+#include <iomanip>
+#include <memory>
+#include <numeric>
+#include <sstream>
+
+using namespace std;
+
+namespace cris::core {
+
+Timeline::Event* Timeline::push(const char* const func) {
+    static thread_local unsigned aux = 0u;
+    if (sess_stack_.empty()) [[unlikely]] {
+        return nullptr;
+    }
+    const auto tic   = GetTSCTick(aux);
+    auto       event = make_unique<Event>(Event{
+        .beg  = tic,
+        .end  = tic,
+        .sess = sess_stack_.top(),
+        .func = func,
+    });
+    events_.push(event.get());
+    const auto toc = GetTSCTick(aux);
+
+    // Overhead from 3 RDTSC (including pop) and lock-free queue.
+    event->overhead = static_cast<long long>((GetTSCTick(aux) - toc) * 3 + (toc - tic));
+    event->end      = toc;
+    return event.release();
+}
+
+Timeline::Event* Timeline::pop(Event* const event) {
+    static thread_local unsigned aux = 0u;
+    if (event) {
+        event->end = GetTSCTick(aux);
+    }
+    return event;
+}
+
+const char* Timeline::start(const char* const sess) {
+    auto& cnt = sess_cnt_[sess];
+    if (!cnt) {
+        sess_stack_.push(sess);
+    } else if (sess_stack_.top() != sess) [[unlikely]] {
+        LOG(ERROR) << "Interleaving timeline \"" << sess << "\" within thread is not supported.";
+        return nullptr;
+    }
+    ++cnt;
+    return sess;
+}
+
+const char* Timeline::pause() {
+    const char* const sess = sess_stack_.top();
+    auto&             cnt  = sess_cnt_[sess];
+    if (!cnt) [[unlikely]] {
+        LOG(ERROR) << "Timeline \"" << sess << "\" is not registered to thread.";
+        return nullptr;
+    }
+    if (!--cnt) {
+        sess_stack_.pop();
+    }
+    return sess;
+}
+
+const char* Timeline::stop() {
+    const char* const sess = sess_stack_.top();
+    auto&             cnt  = sess_cnt_[sess];
+    if (!cnt) [[unlikely]] {
+        LOG(ERROR) << "Timeline \"" << sess << "\" is not registered to thread.";
+        return nullptr;
+    }
+    if (!--cnt) {
+        sess_ready_.push(sess);
+        sess_stack_.pop();
+    }
+    return sess;
+}
+
+void Timeline::print() {
+    // Snapshot.
+    deque<const char*> sess_sel;
+    deque<Event*>      evt_sel;
+    sess_ready_.consume_all([&sess_sel](const char* const sess) { sess_sel.push_back(sess); });
+    events_.consume_all([&evt_sel](Event* const evt) { evt_sel.push_back(evt); });
+
+    // Group by session.
+    unordered_map<const char*, vector<Event*>> sess_evt;
+    for (const char* const sess : sess_sel) {
+        sess_evt[sess];
+    }
+    for (Event* const evt : evt_sel) {
+        if (evt->beg > evt->end) [[unlikely]] {
+            LOG(ERROR) << "Drop invalid event \"" << evt->func << "\" [" << evt->beg << ", " << evt->end
+                       << "] in session \"" << evt->sess << "\".";
+            continue;
+        }
+        auto iter = sess_evt.find(evt->sess);
+        if (iter != sess_evt.end()) {
+            iter->second.push_back(evt);
+        } else {
+            events_.push(evt);
+        }
+    }
+    ostringstream buf;
+    for (auto& entry : sess_evt) {
+        auto& chain = entry.second;
+        if (chain.empty()) {
+            continue;
+        }
+        sort(chain.begin(), chain.end(), [](Event* const lhs, Event* const rhs) { return lhs->beg < rhs->beg; });
+
+        stack<pair<unique_ptr<Event>, long long>> dfs;
+        const auto                                off = chain.front()->beg;
+        const auto                                dur = chain.back()->end - off;
+
+        // 4-char alignment for 3 decimals.
+        const int width = static_cast<int>(to_string(static_cast<long long>(ceil(tsc_to_us(dur)))).size() + 7) >> 2
+                << 2;
+
+        buf.str();
+        buf.clear();
+        buf << setprecision(3) << fixed;
+        {
+            const long long overhead = accumulate(
+                entry.second.begin(),
+                entry.second.end(),
+                0ll,
+                [](const long long acc, const Event* const evt) { return acc + evt->overhead; });
+            buf << "Timeline session \"" << entry.first << "\" took "
+                << tsc_to_us(static_cast<long long>(dur) - overhead) << '+' << tsc_to_us(overhead) << " us:";
+        }
+
+        const string vsplit = '+' + string((static_cast<size_t>(width) << 1) + 3, '-') + '+' +
+            string(static_cast<size_t>(width) + 2, '-') + '+' + string(30, '-');
+        buf << "\n    " << vsplit;
+        buf << "\n    |" << setw(width + 1) << "dur" << setw(width + 2) << left << "+err" << right << '|'
+            << setw(width + 2) << "clk (us) "
+            << "| stack frame";
+        buf << "\n    " << vsplit;
+
+        auto draw = [&buf, &dfs, off, width](const bool pop) {
+            const auto& evt      = *dfs.top().first;
+            const auto  overhead = dfs.top().second;
+            buf << "\n    |";
+            if (pop) {
+                buf << setw(width + 1) << tsc_to_us(static_cast<long long>(evt.end - evt.beg) - overhead) << '+'
+                    << setw(width + 1) << left << tsc_to_us(overhead) << right;
+            } else {
+                buf << setw((width << 1) + 3) << ' ';
+            }
+            buf << '|' << setw(width + 1) << tsc_to_us((pop ? evt.end : evt.beg) - off) << " |"
+                << string(dfs.size() - 1, '|') << (pop ? '/' : '\\') << ' ' << evt.func;
+        };
+        for (Event* const evt : entry.second) {
+            for (long long overhead = 0; !dfs.empty(); dfs.pop()) {
+                overhead = (dfs.top().second += overhead);
+
+                // Assume instant boundary event and partially overlapped event to be child of the early one.
+                if (min(evt->beg + 1, evt->end) <= dfs.top().first->end) {
+                    break;
+                }
+                draw(true);
+            }
+            dfs.emplace(evt, evt->overhead);
+            draw(false);
+        }
+        for (long long overhead = 0; !dfs.empty(); dfs.pop()) {
+            overhead = (dfs.top().second += overhead);
+            draw(true);
+        }
+        buf << "\n    " << vsplit;
+
+        LOG(INFO) << buf.str();
+        buf.str();
+        buf.clear();
+    }
+}
+
+thread_local stack<const char*>          Timeline::sess_stack_;
+thread_local map<const char*, size_t>    Timeline::sess_cnt_;
+boost::lockfree::queue<const char*>      Timeline::sess_ready_(1024);
+boost::lockfree::queue<Timeline::Event*> Timeline::events_(1024);
+thread_local map<string, size_t>         str_pool;
+
+}  // namespace cris::core

--- a/src/utils/timeline.h
+++ b/src/utils/timeline.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "cris/core/utils/time.h"
+
+#if defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wambiguous-reversed-operator"
+#endif
+
+#include <boost/lockfree/queue.hpp>
+
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#include <cstddef>
+#include <map>
+#include <stack>
+#include <string>
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-error)
+#define CRIS_TIMELINE(sess)                                                  \
+    static const ::std::string      cris_timeline_macro_session_name = sess; \
+    ::cris::core::Timeline::Session cris_timeline_macro_session_raii(cris_timeline_macro_session_name.c_str())
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-error)
+#define CRIS_TIMELINE_LOCAL(sess)                                                 \
+    static const ::std::string           cris_timeline_macro_session_name = sess; \
+    ::cris::core::Timeline::LocalSession cris_timeline_macro_session_raii(cris_timeline_macro_session_name.c_str())
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-error)
+#define CRIS_FUNC_TIMELINE_LINE_STR(line) #line
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-error)
+#define CRIS_FUNC_TIMELINE_UNIQ_NAME(suffix) cris_timeline_macro_region_name_##suffix
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-error)
+#define CRIS_FUNC_TIMELINE_UNIQ_RAII(suffix) cris_timeline_macro_region_raii_##suffix
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-error)
+#define CRIS_FUNC_TIMELINE_UNIQ(line)                                                        \
+    static const ::std::string CRIS_FUNC_TIMELINE_UNIQ_NAME(line) =                          \
+        ::std::string(__func__) + "() from " __FILE__ ":" CRIS_FUNC_TIMELINE_LINE_STR(line); \
+    ::cris::core::Timeline::Region CRIS_FUNC_TIMELINE_UNIQ_RAII(line)(CRIS_FUNC_TIMELINE_UNIQ_NAME(line).c_str())
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-error)
+#define CRIS_FUNC_TIMELINE() CRIS_FUNC_TIMELINE_UNIQ(__LINE__)
+
+namespace cris::core {
+
+class Timeline {
+   public:
+    template<typename K, typename V>
+    using map = std::map<K, V>;
+
+    using size_t = std::size_t;
+
+    template<typename T>
+    using stack = std::stack<T>;
+
+    using string = std::string;
+
+    struct Event {
+        unsigned long long beg      = 0;
+        unsigned long long end      = 0;
+        long long          overhead = 0;
+        const char*        sess     = nullptr;
+        const char*        func     = nullptr;
+    };
+
+    class Session {
+       public:
+        using Self = Session;
+
+        Session()            = delete;
+        Session(const Self&) = delete;
+        Session(Self&&)      = delete;
+        Self& operator=(const Self&) = delete;
+        Self& operator=(Self&&) = delete;
+
+        explicit Session(const char* const sess) { start(sess); }
+
+        ~Session() { pause(); }
+    };
+
+    class LocalSession {
+       public:
+        using Self = LocalSession;
+
+        LocalSession()            = delete;
+        LocalSession(const Self&) = delete;
+        LocalSession(Self&&)      = delete;
+        Self& operator=(const Self&) = delete;
+        Self& operator=(Self&&) = delete;
+
+        explicit LocalSession(const char* const sess) { start(sess); }
+
+        ~LocalSession() {
+            stop();
+            print();
+        }
+    };
+
+    class Region {
+       public:
+        using Self = Region;
+
+        Region()            = delete;
+        Region(const Self&) = delete;
+        Region(Self&&)      = delete;
+        Self& operator=(const Self&) = delete;
+        Self& operator=(Self&&) = delete;
+
+        explicit Region(const char* const func) : event_(push(func)) {}
+
+        ~Region() { pop(event_); }
+
+        Event* const event_ = nullptr;
+    };
+
+    Timeline()  = delete;
+    ~Timeline() = default;
+
+    static const char* start(const char* const sess);
+    static const char* pause();
+    static const char* stop();
+    static Event*      push(const char* const func);
+    static Event*      pop(Event* const event);
+    static void        print();
+
+   protected:
+    template<typename T>
+    static double tsc_to_us(const T tsc) {
+        static const double us_per_tsc = kTscToNsecRatio * 1e-3;
+        return static_cast<double>(tsc) * us_per_tsc;
+    };
+
+    static thread_local stack<const char*>       sess_stack_;
+    static thread_local map<const char*, size_t> sess_cnt_;
+    static boost::lockfree::queue<const char*>   sess_ready_;
+    static boost::lockfree::queue<Event*>        events_;
+    static thread_local map<string, size_t>      str_pool;
+};
+
+}  // namespace cris::core

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -214,6 +214,15 @@ cris_cc_test (
 )
 
 cris_cc_test (
+    name = "timeline_test",
+    srcs = ["timeline_test.cc"],
+    deps = [
+        "//:utils",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+
+cris_cc_test (
     name = "timer_test",
     srcs = ["timer_test.cc"],
     deps = [

--- a/tests/timeline_test.cc
+++ b/tests/timeline_test.cc
@@ -1,0 +1,48 @@
+#include "cris/core/utils/timeline.h"
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <vector>
+
+using namespace std;
+
+namespace cris::core {
+
+TEST(Timeline, RAII) {
+    CRIS_TIMELINE_LOCAL("root");
+    CRIS_FUNC_TIMELINE();
+    {
+        Timeline::LocalSession sess("basic");
+        Timeline::Region("test");
+    }
+    {
+        Timeline::Session sess("global");
+        {
+            Timeline::Region("foo");
+            Timeline::Region("bar");
+            CRIS_FUNC_TIMELINE();
+            CRIS_FUNC_TIMELINE();
+        }
+    }
+    {
+        Timeline::LocalSession sess("local");
+        {
+            Timeline::Region("x");
+            {
+                Timeline::Region region_y("y");
+                {
+                    Timeline::Region region_u("u");
+                    []() {
+                        Timeline::Region("lambda");
+                    }();
+                }
+                Timeline::Region("v");
+            }
+            Timeline::Region("z");
+        }
+    }
+    { Timeline::LocalSession sess("global"); }
+}
+
+}  // namespace cris::core


### PR DESCRIPTION
- Use RDTSC to reduce timing overhead.
- Subtract estimated timing overheads from the duration, as system (measurement) error.
- Event-based recording to time RAII ranges.
- LFQ for multi-thread timing.
- Globally (within thread) contextual and stackable timelines, to track regions without passing a timing class everywhere.
- Graphical plotting of the timing stack.

Test logs:
```
Running main() from tests/utils/cris_gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Timeline
[ RUN      ] Timeline.RAII
WARNING: Logging before InitGoogleLogging() is written to STDERR
I20230629 19:14:35.570845  1504 timeline.cc:169] Timeline session "basic" took -0.009+0.102 us:
    +-------------------+----------+------------------------------
    |      dur+err      | clk (us) | stack frame
    +-------------------+----------+------------------------------
    |                   |    0.000 |\ test
    |   -0.009+0.102    |    0.093 |/ test
    +-------------------+----------+------------------------------
I20230629 19:14:35.571053  1504 timeline.cc:169] Timeline session "local" took -0.005+0.913 us:
    +-------------------+----------+------------------------------
    |      dur+err      | clk (us) | stack frame
    +-------------------+----------+------------------------------
    |                   |    0.000 |\ x
    |   -0.008+0.258    |    0.250 |/ x
    |                   |    0.259 |\ y
    |                   |    0.413 ||\ u
    |                   |    0.518 |||\ lambda
    |   -0.010+0.135    |    0.643 |||/ lambda
    |   -0.007+0.251    |    0.657 ||/ u
    |                   |    0.666 ||\ v
    |   -0.008+0.113    |    0.771 ||/ v
    |   -0.007+0.527    |    0.779 |/ y
    |                   |    0.788 |\ z
    |   -0.008+0.128    |    0.908 |/ z
    +-------------------+----------+------------------------------
I20230629 19:14:35.571138  1504 timeline.cc:169] Timeline session "global" took 0.671+0.434 us:
    +-------------------+----------+------------------------------
    |      dur+err      | clk (us) | stack frame
    +-------------------+----------+------------------------------
    |                   |    0.000 |\ foo
    |   -0.010+0.147    |    0.137 |/ foo
    |                   |    0.146 |\ bar
    |   -0.008+0.095    |    0.233 |/ bar
    |                   |    0.747 |\ TestBody() from tests/timeline_test.cc:24
    |                   |    1.028 ||\ TestBody() from tests/timeline_test.cc:25
    |   -0.010+0.088    |    1.105 ||/ TestBody() from tests/timeline_test.cc:25
    |    0.174+0.193    |    1.113 |/ TestBody() from tests/timeline_test.cc:24
    +-------------------+----------+------------------------------
I20230629 19:14:35.571182  1504 timeline.cc:169] Timeline session "root" took 379.769+0.217 us:
    +-------------------+----------+------------------------------
    |      dur+err      | clk (us) | stack frame
    +-------------------+----------+------------------------------
    |                   |    0.000 |\ TestBody() from tests/timeline_test.cc:14
    |  379.769+0.217    |  379.986 |/ TestBody() from tests/timeline_test.cc:14
    +-------------------+----------+------------------------------
[       OK ] Timeline.RAII (0 ms)
[----------] 1 test from Timeline (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
```

Auto-printing across threads is still under development and not covered by unit tests yet.