### PR TITLE
Things in the Macro Body should Always be Fully Qualified

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -277,7 +277,7 @@ template<class T>
 #define CRIS_CONF_JSON_ENTRY_IMPL(var, obj, key, conf, extra_message)    \
     /* NOLINTNEXTLINE(bugprone-macro-parentheses,-warnings-as-errors) */ \
     if (const auto ec = obj[key].get(var)) {                             \
-        FailToParseConfig(conf, extra_message, ec);                      \
+        ::cris::core::FailToParseConfig(conf, extra_message, ec);        \
     }
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-errors)


### PR DESCRIPTION
We cannot assume the scope of the macro caller, so the items used in the macro body must be fully qualified to ensure correctness.