### PR TITLE
PSTL interfaces to Old Toolchains

### DIFF
--- a/src/utils/newcpp/algorithm.h
+++ b/src/utils/newcpp/algorithm.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "cris/core/utils/newcpp/execution.h"
+
+#include <algorithm>
+#include <execution>
+#include <utility>
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-errors)
+#define _CRIS_ALGORITHM_DEFINE_ADAPTER(ns, func)                                      \
+    template<typename... args_t>                                                      \
+    decltype(auto) func(::cris::libs::execution::fallback_policy, args_t&&... args) { \
+        ::cris::libs::execution::impl::PrintFallbackWarningOnce();                    \
+        return ns::func(std::forward<args_t>(args)...);                               \
+    }
+
+namespace std {
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, all_of)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, any_of)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, none_of)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, for_each)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, for_each_n)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, count)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, count_if)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, mismatch)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, find)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, find_if)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, find_if_not)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, find_end)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, find_first_of)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, adjacent_find)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, search)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, search_n)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, copy)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, copy_if)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, copy_n)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, move)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, fill)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, fill_n)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, transform)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, generate)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, generate_n)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, remove)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, remove_if)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, remove_copy)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, remove_copy_if)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, replace_copy)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, replace_copy_if)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, swap_ranges)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, reverse)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, reverse_copy)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, rotate)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, rotate_copy)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, unique)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, unique_copy)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, partition)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, partition_copy)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, stable_partition)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, is_sorted)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, is_sorted_until)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, sort)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, partial_sort)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, partial_sort_copy)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, stable_sort)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, nth_element)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, merge)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, inplace_merge)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, includes)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, set_difference)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, set_intersection)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, set_symmetric_difference)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, set_union)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, is_heap)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, is_heap_until)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, max_element)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, min_element)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, minmax_element)
+
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, equal)
+_CRIS_ALGORITHM_DEFINE_ADAPTER(std, lexicographical_compare)
+
+}  // namespace std
+
+#undef _CRIS_ALGORITHM_DEFINE_ADAPTER

--- a/src/utils/newcpp/execution.cc
+++ b/src/utils/newcpp/execution.cc
@@ -1,0 +1,20 @@
+#include "cris/core/utils/newcpp/execution.h"
+
+#include "cris/core/utils/logging.h"
+
+#include <execution>
+
+namespace cris::libs::execution {
+
+namespace impl {
+
+void PrintFallbackWarningOnce() {
+    [[maybe_unused]] static int print_once = []() {
+        LOG(WARNING) << "The specified execution policy is not available. Falling back to sequential execution.";
+        return 0;
+    }();
+}
+
+}  // namespace impl
+
+}  // namespace cris::libs::execution

--- a/src/utils/newcpp/execution.h
+++ b/src/utils/newcpp/execution.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#if __has_include(<execution>)
+#include <execution>
+#endif
+
+namespace cris::libs::execution {
+
+namespace impl {
+
+void PrintFallbackWarningOnce();
+
+}  // namespace impl
+
+class fallback_policy {};
+
+namespace fallback {
+
+inline constexpr fallback_policy seq;
+inline constexpr fallback_policy par;
+inline constexpr fallback_policy par_unseq;
+inline constexpr fallback_policy unseq;
+
+}  // namespace fallback
+
+}  // namespace cris::libs::execution
+
+// Feature testing macros: https://en.cppreference.com/w/cpp/feature_test#Library_features
+#if defined(__cpp_lib_execution)
+
+#if __cpp_lib_execution >= 201603L
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-errors)
+#define _CR_HAS_STD_EXECUTION_SEQ 1
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-errors)
+#define _CR_HAS_STD_EXECUTION_PAR 1
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-errors)
+#define _CR_HAS_STD_EXECUTION_PAR_UNSEQ 1
+#endif
+
+#if __cpp_lib_execution >= 201902L
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-errors)
+#define _CR_HAS_STD_EXECUTION_UNSEQ 1
+#endif
+
+#endif  // defined(__cpp_lib_execution)
+
+namespace std::execution {
+
+#ifndef _CR_HAS_STD_EXECUTION_SEQ
+using ::cris::libs::execution::fallback::seq;
+#endif
+
+#ifndef _CR_HAS_STD_EXECUTION_PAR
+using ::cris::libs::execution::fallback::par;
+#endif
+
+#ifndef _CR_HAS_STD_EXECUTION_PAR_UNSEQ
+using ::cris::libs::execution::fallback::par_unseq;
+#endif
+
+#ifndef _CR_HAS_STD_EXECUTION_UNSEQ
+using ::cris::libs::execution::fallback::unseq;
+#endif
+
+}  // namespace std::execution

--- a/src/utils/newcpp/numeric.h
+++ b/src/utils/newcpp/numeric.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "cris/core/utils/newcpp/execution.h"
+
+#include <execution>
+#include <numeric>
+#include <utility>
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage,-warnings-as-errors)
+#define _CRIS_NUMERIC_DEFINE_ADAPTER(ns, func)                                        \
+    template<typename... args_t>                                                      \
+    decltype(auto) func(::cris::libs::execution::fallback_policy, args_t&&... args) { \
+        ::cris::libs::execution::impl::PrintFallbackWarningOnce();                    \
+        return ns::func(std::forward<args_t>(args)...);                               \
+    }
+
+namespace std {
+
+_CRIS_NUMERIC_DEFINE_ADAPTER(std, adjacent_difference)
+_CRIS_NUMERIC_DEFINE_ADAPTER(std, reduce)
+_CRIS_NUMERIC_DEFINE_ADAPTER(std, exclusive_scan)
+_CRIS_NUMERIC_DEFINE_ADAPTER(std, inclusive_scan)
+_CRIS_NUMERIC_DEFINE_ADAPTER(std, transform_reduce)
+_CRIS_NUMERIC_DEFINE_ADAPTER(std, transform_exclusive_scan)
+_CRIS_NUMERIC_DEFINE_ADAPTER(std, transform_inclusive_scan)
+
+}  // namespace std
+
+#undef _CRIS_NUMERIC_DEFINE_ADAPTER


### PR DESCRIPTION
Those dummy interfaces provide PSTL-like interfaces when failing to detect the PSTL implementations. So that it allows us to use PSTL parallel functions without breaking the build on the old platforms.