### PR TITLE
Upgrade to checkout v4 due to nodejs deprecation.

### DIFF
--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -25,7 +25,7 @@ runs:
       echo 'CRIS_CACHE_PATHS<<EOF' >> "$GITHUB_ENV"
       printf "%s" "${{ inputs.cache_paths }}" >> "$GITHUB_ENV"
       echo 'EOF' >> "$GITHUB_ENV"
-  - uses: actions/cache@v3
+  - uses: actions/cache@v4
   # PR should not save to shared cache.
     if: ${{ always() && inputs.enable_cache == 'true' && github.event_name != 'pull_request' && ! cancelled() }}
     with:
@@ -41,7 +41,7 @@ runs:
         ${{ inputs.key }}:${{ steps.date.outputs.date-7 }}
         ${{ inputs.key }}:${{ steps.date.outputs.date-8 }}
         ${{ inputs.key }}:${{ steps.date.outputs.date-9 }}
-  - uses: actions/cache/restore@v3
+  - uses: actions/cache/restore@v4
     if: ${{ always() && inputs.enable_cache == 'true' && github.event_name == 'pull_request' && ! cancelled() }}
     with:
       path: ${{ env.CRIS_CACHE_PATHS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     container:
       image: ghcr.io/cyfitech/cris-build-ubuntu2004:20240104
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-lint-env-setup
       with:
         key: ${{ github.job }}
@@ -49,7 +49,7 @@ jobs:
     container:
       image: ghcr.io/cyfitech/cris-build-ubuntu2004:20240104
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-lint-env-setup
       with:
         key: ${{ github.job }}
@@ -68,7 +68,7 @@ jobs:
       CC: clang-12
       CXX: clang++-12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -87,7 +87,7 @@ jobs:
       CC: clang-13
       CXX: clang++-13
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -105,7 +105,7 @@ jobs:
       CC: clang-14
       CXX: clang++-14
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -123,7 +123,7 @@ jobs:
       CC: clang-15
       CXX: clang++-15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -141,7 +141,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -160,7 +160,7 @@ jobs:
       CC: gcc-10
       CXX: g++-10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -178,7 +178,7 @@ jobs:
       CC: gcc-11
       CXX: g++-11
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -196,7 +196,7 @@ jobs:
       CC: gcc-12
       CXX: g++-12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -214,7 +214,7 @@ jobs:
       CC: clang-13
       CXX: clang++-13
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -230,7 +230,7 @@ jobs:
       CC: clang-13
       CXX: clang++-13
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}
@@ -246,7 +246,7 @@ jobs:
       CC: clang-13
       CXX: clang++-13
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-build-env-setup
       with:
         key: ${{ github.job }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Config
       id: docker-build-config
       env:
@@ -82,7 +82,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Config
       id: docker-build-config
       env:
@@ -142,7 +142,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Config
       id: docker-build-config
       env:
@@ -201,7 +201,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Config
       id: docker-build-config
       env:
@@ -261,7 +261,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Config
       id: docker-build-config
       env:
@@ -320,7 +320,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Config
       id: docker-build-config
       env:
@@ -380,7 +380,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Config
       id: docker-build-config
       env:
@@ -439,7 +439,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Config
       id: docker-build-config
       env:


### PR DESCRIPTION
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/