### PR TITLE
Stop Creating New Sections If Full

### DIFF
--- a/src/timer/timer.h
+++ b/src/timer/timer.h
@@ -122,6 +122,9 @@ class TimerSection {
 
     static std::unique_ptr<TimerReport> GetAllReports(bool clear);
 
+    // Max number of sections to create.
+    static constexpr std::size_t kMaxCapacity = 8192;
+
    private:
     std::string                                          name_;
     [[PRIVATE_MAYBE_UNUSED]] std::size_t                 collector_index_{0};

--- a/src/timer/timer_enable.cc
+++ b/src/timer/timer_enable.cc
@@ -433,7 +433,7 @@ TimerSection* TimerSection::SubSection(const std::string& name) {
     }
 
     const std::size_t collector_idx = collector_index_count.fetch_add(1);
-    std::unique_lock  lock(shared_mtx_);
+    std::lock_guard   lock(shared_mtx_);
     if (collector_idx >= TimerStatCollector::kCollectorSize) {
         LOG(ERROR) << __func__ << ": Timer Is Full. Too Many Sections Are Created. "
                    << "Ignored \"" << name << "\".";

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -234,6 +234,15 @@ cris_cc_test (
 )
 
 cris_cc_test (
+    name = "timer_full_test",
+    srcs = ["timer_full_test.cc"],
+    deps = [
+        "//:timer",
+        "@cris-core//tests:cris_gtest_main",
+    ],
+)
+
+cris_cc_test (
     name = "simple_timer_test",
     srcs = ["simple_timer_test.cc"],
     deps = [

--- a/tests/timer_full_test.cc
+++ b/tests/timer_full_test.cc
@@ -1,0 +1,23 @@
+#include "cris/core/timer/timer.h"
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <cstddef>
+#include <thread>
+
+namespace cris::core {
+
+TEST(TimerFullTest, TimerIsFull) {
+    constexpr std::size_t kTestSectionNum = 300000;
+    EXPECT_GT(kTestSectionNum, TimerSection::kMaxCapacity);
+    auto* main_section = TimerSection::GetMainSection();
+    for (std::size_t i = 0; i < kTestSectionNum; ++i) {
+        auto* section = main_section->SubSection(std::to_string(i));
+        ASSERT_NE(section, nullptr);
+        auto session = section->StartTimerSession();
+    }
+    TimerSection::GetAllReports(/*clear = */ true)->PrintToLog();
+}
+
+}  // namespace cris::core


### PR DESCRIPTION
It avoids potential crash and limits the memory usage.