### PR TITLE
Fix Memory leaking from the Thread Local Objects

### DIFF
--- a/src/timer/timer_enable.cc
+++ b/src/timer/timer_enable.cc
@@ -140,6 +140,7 @@ TimerStatCollector& TimerStatCollector::GetCollector() {
     // This unique_ptr does not manage the ownership of the collector, but free the collector
     // from the list when the thread exits.
     static const auto colllector_deleter = [](TimerStatCollector* collector) {
+        GetTotalStats().Merge(collector->Collect(/*clear = */ true));
         GetCollectorList().LockAndThen([collector](auto& collectors) {
             std::erase_if(collectors, [collector](const auto& item) { return item.get() == collector; });
         });


### PR DESCRIPTION
The thread local timer stat collectors will be kept in a global collector list. So their collectors will be orphaned when the threads exit. Then there is memory leaking.

This patch cleans up the collector in the global list when a thread exits.