### PR TITLE
Disable Bzlmod for Offline Build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,9 @@ build --copt="-DSIMDJSON_EXCEPTIONS=0"
 build --cxxopt="-std=c++20"
 build -c opt
 
+# Disable Bzlmod because of offline build.
+build --enable_bzlmod=false
+
 try-import %workspace%/run/toolchain.bazelrc
 
 build:_zlib64 --copt="-D_FILE_OFFSET_BITS=64"


### PR DESCRIPTION
Bazel 7 enables bzlmod by default and requiring online access to Bazel registry. So we disable bzlmod and use the legacy mode allowing offline build.