### PR TITLE
Build simdjson with `-fPIC` | Update deprecated CMake flags | Whitelist cache

### DIFF
--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -65,6 +65,7 @@ runs:
       ccache -psvx
       git config --global --add safe.directory "$(pwd)"
       mkdir -p ~/{.cache/{bazel,ccache,pip},.ccache}
+      env
   - name: Auth
     shell: bash
     run: |

--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -63,6 +63,7 @@ runs:
       export HOME=/root
       ccache -M 1GiB -o compression=true -o compression_level=5
       ccache -svx
+      ccache --show-config
       git config --global --add safe.directory "$(pwd)"
       mkdir -p ~/{.cache/{bazel,ccache,pip},.ccache}
   - name: Auth

--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -65,7 +65,6 @@ runs:
       ccache -psvx
       git config --global --add safe.directory "$(pwd)"
       mkdir -p ~/{.cache/{bazel,ccache,pip},.ccache}
-      env
   - name: Auth
     shell: bash
     run: |

--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -62,8 +62,7 @@ runs:
       set -xe
       export HOME=/root
       ccache -M 1GiB -o compression=true -o compression_level=5
-      ccache -svx
-      ccache --show-config
+      ccache -psvx
       git config --global --add safe.directory "$(pwd)"
       mkdir -p ~/{.cache/{bazel,ccache,pip},.ccache}
   - name: Auth

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Config
       run: export HOME=/root && git config --global --add safe.directory "$(pwd)"
     - name: Run tidy
-      run: export HOME=/root && make -j tidy -o lint
+      run: export HOME=/root && make -j tidy -o lint OPT='--verbose_failures'
     - name: Check diff
       run: export HOME=/root && git --no-pager diff --exit-code
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Config
       run: export HOME=/root && git config --global --add safe.directory "$(pwd)"
     - name: Run tidy
-      run: export HOME=/root && make -j tidy -o lint OPT='--verbose_failures'
+      run: export HOME=/root && make -j tidy -o lint
     - name: Check diff
       run: export HOME=/root && git --no-pager diff --exit-code
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -189,6 +189,7 @@ cmake(
         "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_C_FLAGS" : "-Wno-fuse-ld-path",
         "CMAKE_CXX_FLAGS" : "-Wno-fuse-ld-path",
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
         "SIMDJSON_DEVELOPER_MODE": "OFF",
         "SIMDJSON_EXCEPTIONS": "OFF",
     },

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -186,9 +186,11 @@ cmake(
     name = "libsimdjson",
     lib_source = ":all_content",
     cache_entries = {
-        "BUILD_SHARED_LIBS": "OFF",
+        # TODO: Replace SIMDJSON_BUILD_STATIC with BUILD_SHARED_LIBS.
+        # "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_C_FLAGS" : "-Wno-fuse-ld-path",
         "CMAKE_CXX_FLAGS" : "-Wno-fuse-ld-path",
+        "SIMDJSON_BUILD_STATIC": "ON",
         "SIMDJSON_DEVELOPER_MODE": "OFF",
         "SIMDJSON_EXCEPTIONS": "OFF",
     },

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -186,11 +186,11 @@ cmake(
     name = "libsimdjson",
     lib_source = ":all_content",
     cache_entries = {
+        "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_C_FLAGS" : "-Wno-fuse-ld-path",
         "CMAKE_CXX_FLAGS" : "-Wno-fuse-ld-path",
-        "SIMDJSON_BUILD_STATIC": "ON",
+        "SIMDJSON_DEVELOPER_MODE": "OFF",
         "SIMDJSON_EXCEPTIONS": "OFF",
-        "SIMDJSON_JUST_LIBRARY": "ON",
     },
     generate_args = [
         "-G Ninja",

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -186,11 +186,9 @@ cmake(
     name = "libsimdjson",
     lib_source = ":all_content",
     cache_entries = {
-        # TODO: Replace SIMDJSON_BUILD_STATIC with BUILD_SHARED_LIBS.
-        # "BUILD_SHARED_LIBS": "OFF",
+        "BUILD_SHARED_LIBS": "OFF",
         "CMAKE_C_FLAGS" : "-Wno-fuse-ld-path",
         "CMAKE_CXX_FLAGS" : "-Wno-fuse-ld-path",
-        "SIMDJSON_BUILD_STATIC": "ON",
         "SIMDJSON_DEVELOPER_MODE": "OFF",
         "SIMDJSON_EXCEPTIONS": "OFF",
     },

--- a/scripts/bazel_wrapper.sh
+++ b/scripts/bazel_wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 cd "$(dirname "$0")/.."
 

--- a/scripts/bazel_wrapper.sh
+++ b/scripts/bazel_wrapper.sh
@@ -45,21 +45,25 @@ bazel "$BAZEL_CMD"                                                              
     --sandbox_writable_path="$(set -e;                                              \
         which ccache >/dev/null 2>&1                                                \
         && [ "$HOME" ]                                                              \
+        && [ -e "$HOME/.ccache" ]                                                   \
         && printf '%s/.ccache' "$HOME"                                              \
         || printf '/dev/null')"                                                     \
     --sandbox_writable_path="$(set -e;                                              \
         which ccache >/dev/null 2>&1                                                \
         && [ "$HOME" ]                                                              \
+        && [ -e "$HOME/.cache/ccache" ]                                             \
         && printf '%s/.cache/ccache' "$HOME"                                        \
         || printf '/dev/null')"                                                     \
     --sandbox_writable_path="$(set -e;                                              \
         which ccache >/dev/null 2>&1                                                \
         && [ "$HOME" ]                                                              \
+        && [ -e "$HOME/Library/Caches/ccache" ]                                     \
         && printf '%s/Library/Caches/ccache' "$HOME"                                \
         || printf '/dev/null')"                                                     \
     --sandbox_writable_path="$(set -e;                                              \
         which ccache >/dev/null 2>&1                                                \
         && [ "$XDG_CACHE_HOME" ]                                                    \
+        && [ -e "$XDG_CACHE_HOME/ccache" ]                                          \
         && printf '%s/ccache' "$XDG_CACHE_HOME"                                     \
         || printf '/dev/null')"                                                     \
     "$@"

--- a/scripts/bazel_wrapper.sh
+++ b/scripts/bazel_wrapper.sh
@@ -16,12 +16,14 @@ fi
 BAZEL_CMD="$1"
 shift
 
-# Need to set PATH instead of CC because Bazel does not like '/'s in the CC value.
+# - Need to set PATH instead of CC because Bazel does not like '/'s in the CC value.
+# - Whitelist ccache dir in Bazel sandbox.
+#   https://ccache.dev/manual/latest.html#config_cache_dir
 PATH="$([ ! "$CC"  ] || dirname  "$CC" ):$([ ! "$CXX" ] || dirname "$CXX"):$PATH"   \
 CC="$(  [ ! "$CC"  ] || basename "$CC" )"                                           \
 CXX="$( [ ! "$CXX" ] || basename "$CXX")"                                           \
 bazel "$BAZEL_CMD"                                                                  \
-    --experimental_ui_max_stdouterr_bytes=-1				            \
+    --experimental_ui_max_stdouterr_bytes=-1                                        \
     --sandbox_writable_path="$(set -e;                                              \
         which ccache >/dev/null 2>&1                                                \
         && ccache --show-config 2>/dev/null                                         \
@@ -44,6 +46,16 @@ bazel "$BAZEL_CMD"                                                              
         which ccache >/dev/null 2>&1                                                \
         && [ "$HOME" ]                                                              \
         && printf '%s/.ccache' "$HOME"                                              \
+        || printf '/dev/null')"                                                     \
+    --sandbox_writable_path="$(set -e;                                              \
+        which ccache >/dev/null 2>&1                                                \
+        && [ "$HOME" ]                                                              \
+        && printf '%s/.cache/ccache' "$HOME"                                        \
+        || printf '/dev/null')"                                                     \
+    --sandbox_writable_path="$(set -e;                                              \
+        which ccache >/dev/null 2>&1                                                \
+        && [ "$HOME" ]                                                              \
+        && printf '%s/Library/Caches/ccache' "$HOME"                                \
         || printf '/dev/null')"                                                     \
     --sandbox_writable_path="$(set -e;                                              \
         which ccache >/dev/null 2>&1                                                \

--- a/scripts/bazel_wrapper.sh
+++ b/scripts/bazel_wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 cd "$(dirname "$0")/.."
 

--- a/scripts/bazel_wrapper.sh
+++ b/scripts/bazel_wrapper.sh
@@ -31,6 +31,7 @@ bazel "$BAZEL_CMD"                                                              
         | sed 's/[[:space:]]*$//'                                                   \
         | sed -n 's/^cache_dir[[:space:]]*=[[:space:]]*//pi'                        \
         | head -n1                                                                  \
+        | xargs -rI{} find {} -maxdepth 0 2>/dev/null                               \
         | grep .                                                                    \
         || printf '/dev/null')"                                                     \
     --sandbox_writable_path="$(set -e;                                              \
@@ -40,6 +41,7 @@ bazel "$BAZEL_CMD"                                                              
         | sed 's/[[:space:]]*$//'                                                   \
         | sed -n 's/^temporary_dir[[:space:]]*=[[:space:]]*//pi'                    \
         | head -n1                                                                  \
+        | xargs -rI{} find {} -maxdepth 0 2>/dev/null                               \
         | grep .                                                                    \
         || printf '/dev/null')"                                                     \
     --sandbox_writable_path="$(set -e;                                              \

--- a/scripts/bazel_wrapper.sh
+++ b/scripts/bazel_wrapper.sh
@@ -40,6 +40,16 @@ bazel "$BAZEL_CMD"                                                              
         | head -n1                                                                  \
         | grep .                                                                    \
         || printf '/dev/null')"                                                     \
+    --sandbox_writable_path="$(set -e;                                              \
+        which ccache >/dev/null 2>&1                                                \
+        && [ "$HOME" ]                                                              \
+        && printf '%s/.ccache' "$HOME"                                              \
+        || printf '/dev/null')"                                                     \
+    --sandbox_writable_path="$(set -e;                                              \
+        which ccache >/dev/null 2>&1                                                \
+        && [ "$XDG_CACHE_HOME" ]                                                    \
+        && printf '%s/ccache' "$XDG_CACHE_HOME"                                     \
+        || printf '/dev/null')"                                                     \
     "$@"
 
 ! which ccache >/dev/null 2>&1 || ccache -s >&2


### PR DESCRIPTION
Found deprecation notice in build log:
```
CMake Deprecation Warning at cmake/handle-deprecations.cmake:2 (message):
  SIMDJSON_BUILD_STATIC is deprecated, setting BUILD_SHARED_LIBS with its
  value and unsetting it
Call Stack (most recent call first):
  CMakeLists.txt:56 (include)


CMake Deprecation Warning at cmake/handle-deprecations.cmake:14 (message):
  SIMDJSON_JUST_LIBRARY is deprecated, setting SIMDJSON_DEVELOPER_MODE with
  its value and unsetting it
Call Stack (most recent call first):
  CMakeLists.txt:56 (include)
```

Bazel somehow uses `.ccache` while `ccache -p` shows `.cache/ccache`.
Possibly due to Bazel create inaccessible mount on non-existing dir.